### PR TITLE
feat: add handling and tests for wrapping reserved words in package n…

### DIFF
--- a/processor/src/main/kotlin/io/github/doljae/common/StringUtility.kt
+++ b/processor/src/main/kotlin/io/github/doljae/common/StringUtility.kt
@@ -1,0 +1,19 @@
+package io.github.doljae.common
+
+object StringUtility {
+    fun wrapReservedWords(
+        target: String,
+        delimiter: Char,
+        reservedWords: Collection<String>,
+        quoteChar: Char,
+    ): String {
+        val tokens = target.split(delimiter)
+        return tokens.joinToString(delimiter.toString()) { token ->
+            if (reservedWords.contains(token)) {
+                "$quoteChar$token$quoteChar"
+            } else {
+                token
+            }
+        }
+    }
+}

--- a/processor/src/main/kotlin/io/github/doljae/kotlinlogging/extensions/LoggerProcessor.kt
+++ b/processor/src/main/kotlin/io/github/doljae/kotlinlogging/extensions/LoggerProcessor.kt
@@ -7,11 +7,54 @@ import com.google.devtools.ksp.processing.Resolver
 import com.google.devtools.ksp.processing.SymbolProcessor
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSClassDeclaration
+import io.github.doljae.common.StringUtility.wrapReservedWords
 
 class LoggerProcessor(
     private val codeGenerator: CodeGenerator,
     private val logger: KSPLogger,
 ) : SymbolProcessor {
+    override fun process(resolver: Resolver): List<KSAnnotated> {
+        val classes =
+            resolver
+                .getNewFiles()
+                .flatMap { file -> file.declarations.filterIsInstance<KSClassDeclaration>() }
+
+        classes.forEach { classDeclaration ->
+            generateLogger(classDeclaration)
+        }
+
+        return emptyList()
+    }
+
+    private fun generateLogger(classDeclaration: KSClassDeclaration) {
+        val className = classDeclaration.simpleName.asString()
+        val loggerCode =
+            """
+            package ${classDeclaration.packageName.asString()}
+            
+            import io.github.oshai.kotlinlogging.KLogger
+            import io.github.oshai.kotlinlogging.KotlinLogging
+            
+            val $className.log: KLogger
+                get() = KotlinLogging.logger("${classDeclaration.qualifiedName!!.asString()}")
+            """.trimIndent()
+
+        codeGenerator
+            .createNewFile(
+                Dependencies(false),
+                wrapReservedWords(
+                    target = classDeclaration.packageName.asString(),
+                    delimiter = '.',
+                    reservedWords = hardKeywords,
+                    quoteChar = '`',
+                ),
+                "${className}KotlinLoggingExtensions",
+            ).bufferedWriter()
+            .use { writer ->
+                writer.write(loggerCode)
+            }
+    }
+
     companion object {
         // Ref: https://kotlinlang.org/docs/keyword-reference.html
         private val hardKeywords =
@@ -45,58 +88,5 @@ class LoggerProcessor(
                 "when",
                 "while",
             )
-
-        fun String.wrapReservedWords(
-            delimiter: Char,
-            reservedWords: Collection<String>,
-            quoteChar: Char,
-        ): String {
-            val tokens = split(delimiter)
-            return tokens.joinToString(delimiter.toString()) { token ->
-                if (reservedWords.contains(token)) {
-                    "$quoteChar$token$quoteChar"
-                } else {
-                    token
-                }
-            }
-        }
-    }
-
-    override fun process(resolver: Resolver): List<KSAnnotated> {
-        val classes =
-            resolver
-                .getNewFiles()
-                .flatMap { file -> file.declarations.filterIsInstance<KSClassDeclaration>() }
-
-        classes.forEach { classDeclaration ->
-            generateLogger(classDeclaration)
-        }
-
-        return emptyList()
-    }
-
-    private fun generateLogger(classDeclaration: KSClassDeclaration) {
-        val className = classDeclaration.simpleName.asString()
-        val loggerCode =
-            """
-            package ${classDeclaration.packageName.asString()}
-            
-            import io.github.oshai.kotlinlogging.KLogger
-            import io.github.oshai.kotlinlogging.KotlinLogging
-            
-            val $className.log: KLogger
-                get() = KotlinLogging.logger("${classDeclaration.qualifiedName!!.asString()}")
-            """.trimIndent()
-
-        codeGenerator
-            .createNewFile(
-                Dependencies(false),
-                classDeclaration.packageName.asString()
-                    .wrapReservedWords(delimiter = '.', reservedWords = keywords, quoteChar = '`'),
-                "${className}KotlinLoggingExtensions",
-            ).bufferedWriter()
-            .use { writer ->
-                writer.write(loggerCode)
-            }
     }
 }

--- a/processor/src/main/kotlin/io/github/doljae/kotlinlogging/extensions/LoggerProcessor.kt
+++ b/processor/src/main/kotlin/io/github/doljae/kotlinlogging/extensions/LoggerProcessor.kt
@@ -13,7 +13,8 @@ class LoggerProcessor(
     private val logger: KSPLogger,
 ) : SymbolProcessor {
     companion object {
-        private val keywords =
+        // Ref: https://kotlinlang.org/docs/keyword-reference.html
+        private val hardKeywords =
             setOf(
                 "as",
                 "break",

--- a/processor/src/main/kotlin/io/github/doljae/kotlinlogging/extensions/LoggerProcessor.kt
+++ b/processor/src/main/kotlin/io/github/doljae/kotlinlogging/extensions/LoggerProcessor.kt
@@ -12,6 +12,55 @@ class LoggerProcessor(
     private val codeGenerator: CodeGenerator,
     private val logger: KSPLogger,
 ) : SymbolProcessor {
+    companion object {
+        private val keywords =
+            setOf(
+                "as",
+                "break",
+                "class",
+                "continue",
+                "do",
+                "else",
+                "false",
+                "for",
+                "fun",
+                "if",
+                "in",
+                "interface",
+                "is",
+                "null",
+                "object",
+                "package",
+                "return",
+                "super",
+                "this",
+                "throw",
+                "true",
+                "try",
+                "typealias",
+                "typeof",
+                "val",
+                "var",
+                "when",
+                "while",
+            )
+
+        fun String.wrapReservedWords(
+            delimiter: Char,
+            reservedWords: Collection<String>,
+            quoteChar: Char,
+        ): String {
+            val tokens = split(delimiter)
+            return tokens.joinToString(delimiter.toString()) { token ->
+                if (reservedWords.contains(token)) {
+                    "$quoteChar$token$quoteChar"
+                } else {
+                    token
+                }
+            }
+        }
+    }
+
     override fun process(resolver: Resolver): List<KSAnnotated> {
         val classes =
             resolver
@@ -41,7 +90,8 @@ class LoggerProcessor(
         codeGenerator
             .createNewFile(
                 Dependencies(false),
-                classDeclaration.packageName.asString(),
+                classDeclaration.packageName.asString()
+                    .wrapReservedWords(delimiter = '.', reservedWords = keywords, quoteChar = '`'),
                 "${className}KotlinLoggingExtensions",
             ).bufferedWriter()
             .use { writer ->

--- a/processor/src/test/kotlin/io/github/doljae/common/StringUtilityTest.kt
+++ b/processor/src/test/kotlin/io/github/doljae/common/StringUtilityTest.kt
@@ -1,0 +1,185 @@
+package io.github.doljae.common
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class StringUtilityTest {
+    private val reservedWords =
+        setOf(
+            "as",
+            "break",
+            "class",
+            "continue",
+            "do",
+            "else",
+            "false",
+            "for",
+            "fun",
+            "if",
+            "in",
+            "interface",
+            "is",
+            "null",
+            "object",
+            "package",
+            "return",
+            "super",
+            "this",
+            "throw",
+            "true",
+            "try",
+            "typealias",
+            "typeof",
+            "val",
+            "var",
+            "when",
+            "while",
+        )
+    private val quoteChar = '`'
+    private val delimiter = '.'
+
+    @Test
+    fun `should not modify string without reserved words`() {
+        val input = "com.example.project"
+        val expected = "com.example.project"
+
+        val actual =
+            StringUtility.wrapReservedWords(
+                target = input,
+                delimiter = delimiter,
+                reservedWords = reservedWords,
+                quoteChar = quoteChar,
+            )
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should wrap single reserved word in a path`() {
+        val input = "com.package.example"
+        val expected = "com.`package`.example"
+
+        val actual =
+            StringUtility.wrapReservedWords(
+                target = input,
+                delimiter = delimiter,
+                reservedWords = reservedWords,
+                quoteChar = quoteChar,
+            )
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should wrap multiple reserved words in a path`() {
+        val input = "my.package.is.fun"
+        val expected = "my.`package`.`is`.`fun`"
+
+        val actual =
+            StringUtility.wrapReservedWords(
+                target = input,
+                delimiter = delimiter,
+                reservedWords = reservedWords,
+                quoteChar = quoteChar,
+            )
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should wrap reserved words at beginning of path`() {
+        val input = "fun.in.my.project"
+        val expected = "`fun`.`in`.my.project"
+
+        val actual =
+            StringUtility.wrapReservedWords(
+                target = input,
+                delimiter = delimiter,
+                reservedWords = reservedWords,
+                quoteChar = quoteChar,
+            )
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should wrap single word that is reserved`() {
+        val input = "package"
+        val expected = "`package`"
+
+        val actual =
+            StringUtility.wrapReservedWords(
+                target = input,
+                delimiter = delimiter,
+                reservedWords = reservedWords,
+                quoteChar = quoteChar,
+            )
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should handle empty string`() {
+        val input = ""
+        val expected = ""
+
+        val actual =
+            StringUtility.wrapReservedWords(
+                target = input,
+                delimiter = delimiter,
+                reservedWords = reservedWords,
+                quoteChar = quoteChar,
+            )
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should handle different delimiter`() {
+        val input = "one/if/two/when"
+        val expected = "one/`if`/two/`when`"
+
+        val actual =
+            StringUtility.wrapReservedWords(
+                target = input,
+                delimiter = '/',
+                reservedWords = reservedWords,
+                quoteChar = quoteChar,
+            )
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should handle different quote character`() {
+        val input = "com.package.class"
+        val expected = "com.'package'.'class'"
+
+        val actual =
+            StringUtility.wrapReservedWords(
+                target = input,
+                delimiter = delimiter,
+                reservedWords = reservedWords,
+                quoteChar = '\'',
+            )
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `should handle custom reserved words set`() {
+        val input = "foo.bar.baz"
+        val expected = "`foo`.bar.`baz`"
+        val customReservedWords = setOf("foo", "baz")
+
+        val actual =
+            StringUtility.wrapReservedWords(
+                target = input,
+                delimiter = delimiter,
+                reservedWords = customReservedWords,
+                quoteChar = quoteChar,
+            )
+
+        assertEquals(expected, actual)
+    }
+}

--- a/processor/src/test/kotlin/io/github/doljae/kotlinlogging/extensions/LoggerProcessorTest.kt
+++ b/processor/src/test/kotlin/io/github/doljae/kotlinlogging/extensions/LoggerProcessorTest.kt
@@ -1,8 +1,6 @@
 package io.github.doljae.kotlinlogging.extensions
 
-import io.github.doljae.kotlinlogging.extensions.LoggerProcessor.Companion.wrapReservedWords
 import kotlin.test.Test
-import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class LoggerProcessorTest {
@@ -23,81 +21,5 @@ class LoggerProcessorTest {
 
         val processorName = LoggerProcessor::class.simpleName
         assertTrue(processorName == "LoggerProcessor", "Processor class has correct name")
-    }
-
-    @Test
-    fun `package name should handle reserved words correctly`() {
-        // A subset of Kotlin keywords to test the wrapping logic,
-        // mirroring the keywords in LoggerProcessor.
-        val reservedWords =
-            setOf(
-                "as",
-                "break",
-                "class",
-                "continue",
-                "do",
-                "else",
-                "for",
-                "fun",
-                "if",
-                "in",
-                "is",
-                "null",
-                "object",
-                "package",
-                "return",
-                "super",
-                "this",
-                "throw",
-                "try",
-                "typealias",
-                "typeof",
-                "val",
-                "var",
-                "when",
-                "while",
-            )
-        val delimiter = '.'
-        val quoteChar = '`'
-
-        // Test case 1: Package name with a common reserved word "in"
-        val packageName1 = "com.katfun.tech.share.sample.codes.in"
-        val expected1 = "com.katfun.tech.share.sample.codes.`in`"
-        assertEquals(expected1, packageName1.wrapReservedWords(delimiter, reservedWords, quoteChar))
-
-        // Test case 2: Package name with multiple reserved words
-        val packageName2 = "package.io.github.class.for.val"
-        val expected2 = "`package`.io.github.`class`.`for`.`val`"
-        assertEquals(expected2, packageName2.wrapReservedWords(delimiter, reservedWords, quoteChar))
-
-        // Test case 3: Package name with no reserved words
-        val packageName3 = "org.example.application.utils"
-        val expected3 = "org.example.application.utils"
-        assertEquals(expected3, packageName3.wrapReservedWords(delimiter, reservedWords, quoteChar))
-
-        // Test case 4: Package name where part of a token contains a reserved word (should not wrap)
-        val packageName4 = "my.classy.stuff.inside.values"
-        val expected4 = "my.classy.stuff.inside.values"
-        assertEquals(expected4, packageName4.wrapReservedWords(delimiter, reservedWords, quoteChar))
-
-        // Test case 5: Empty package name
-        val packageName5 = ""
-        val expected5 = ""
-        assertEquals(expected5, packageName5.wrapReservedWords(delimiter, reservedWords, quoteChar))
-
-        // Test case 6: Package name that is a single reserved word
-        val packageName6 = "class"
-        val expected6 = "`class`"
-        assertEquals(expected6, packageName6.wrapReservedWords(delimiter, reservedWords, quoteChar))
-
-        // Test case 7: Package name with reserved word at the beginning
-        val packageName7 = "fun.project.app"
-        val expected7 = "`fun`.project.app"
-        assertEquals(expected7, packageName7.wrapReservedWords(delimiter, reservedWords, quoteChar))
-
-        // Test case 8: Package name with reserved word at the end and no others
-        val packageName8 = "another.example.object"
-        val expected8 = "another.example.`object`"
-        assertEquals(expected8, packageName8.wrapReservedWords(delimiter, reservedWords, quoteChar))
     }
 }

--- a/processor/src/test/kotlin/io/github/doljae/kotlinlogging/extensions/LoggerProcessorTest.kt
+++ b/processor/src/test/kotlin/io/github/doljae/kotlinlogging/extensions/LoggerProcessorTest.kt
@@ -1,6 +1,8 @@
 package io.github.doljae.kotlinlogging.extensions
 
+import io.github.doljae.kotlinlogging.extensions.LoggerProcessor.Companion.wrapReservedWords
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class LoggerProcessorTest {
@@ -21,5 +23,81 @@ class LoggerProcessorTest {
 
         val processorName = LoggerProcessor::class.simpleName
         assertTrue(processorName == "LoggerProcessor", "Processor class has correct name")
+    }
+
+    @Test
+    fun `package name should handle reserved words correctly`() {
+        // A subset of Kotlin keywords to test the wrapping logic,
+        // mirroring the keywords in LoggerProcessor.
+        val reservedWords =
+            setOf(
+                "as",
+                "break",
+                "class",
+                "continue",
+                "do",
+                "else",
+                "for",
+                "fun",
+                "if",
+                "in",
+                "is",
+                "null",
+                "object",
+                "package",
+                "return",
+                "super",
+                "this",
+                "throw",
+                "try",
+                "typealias",
+                "typeof",
+                "val",
+                "var",
+                "when",
+                "while",
+            )
+        val delimiter = '.'
+        val quoteChar = '`'
+
+        // Test case 1: Package name with a common reserved word "in"
+        val packageName1 = "com.katfun.tech.share.sample.codes.in"
+        val expected1 = "com.katfun.tech.share.sample.codes.`in`"
+        assertEquals(expected1, packageName1.wrapReservedWords(delimiter, reservedWords, quoteChar))
+
+        // Test case 2: Package name with multiple reserved words
+        val packageName2 = "package.io.github.class.for.val"
+        val expected2 = "`package`.io.github.`class`.`for`.`val`"
+        assertEquals(expected2, packageName2.wrapReservedWords(delimiter, reservedWords, quoteChar))
+
+        // Test case 3: Package name with no reserved words
+        val packageName3 = "org.example.application.utils"
+        val expected3 = "org.example.application.utils"
+        assertEquals(expected3, packageName3.wrapReservedWords(delimiter, reservedWords, quoteChar))
+
+        // Test case 4: Package name where part of a token contains a reserved word (should not wrap)
+        val packageName4 = "my.classy.stuff.inside.values"
+        val expected4 = "my.classy.stuff.inside.values"
+        assertEquals(expected4, packageName4.wrapReservedWords(delimiter, reservedWords, quoteChar))
+
+        // Test case 5: Empty package name
+        val packageName5 = ""
+        val expected5 = ""
+        assertEquals(expected5, packageName5.wrapReservedWords(delimiter, reservedWords, quoteChar))
+
+        // Test case 6: Package name that is a single reserved word
+        val packageName6 = "class"
+        val expected6 = "`class`"
+        assertEquals(expected6, packageName6.wrapReservedWords(delimiter, reservedWords, quoteChar))
+
+        // Test case 7: Package name with reserved word at the beginning
+        val packageName7 = "fun.project.app"
+        val expected7 = "`fun`.project.app"
+        assertEquals(expected7, packageName7.wrapReservedWords(delimiter, reservedWords, quoteChar))
+
+        // Test case 8: Package name with reserved word at the end and no others
+        val packageName8 = "another.example.object"
+        val expected8 = "another.example.`object`"
+        assertEquals(expected8, packageName8.wrapReservedWords(delimiter, reservedWords, quoteChar))
     }
 }


### PR DESCRIPTION
feat: add handling and tests for wrapping reserved words in package names
- Added String.wrapReservedWords() method to split a string, distinguish with reserved words, and wrap them with quotechar
- Added a set of Kotlin's keywords (from https://kotlinlang.org/docs/keyword-reference.html)
- Added a unit test to verify String.wrapReservedWords() function as expected

## Motivation

- Package names, sucn as `in`, are often used, but are Kotlin's predefined keywords. This request enforces kotlin-logging-extensions's accessibility to those using keywords as their application's package names.

Closes #24 

## Modification

<!-- What was changed? -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other: 

## Result

<!-- How was it tested/verified? -->

- [x] Tests added/updated
- [x] Manual testing completed  
- [x] `./gradlew test` passes
- [x] `./gradlew ktlintCheck` passes

## Additional Notes

<!-- Any additional context --> 