### PR TITLE
fix(deps): update all pending dependency versions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ import org.jlleitschuh.gradle.ktlint.KtlintExtension
 
 plugins {
     kotlin("jvm") version "2.3.21" apply false
-    id("com.google.devtools.ksp") version "2.3.8" apply false
+    id("com.google.devtools.ksp") version "2.3.9" apply false
     id("com.vanniktech.maven.publish") version "0.36.0" apply false
     id("org.jlleitschuh.gradle.ktlint") version "14.2.0"
 }

--- a/processor/build.gradle.kts
+++ b/processor/build.gradle.kts
@@ -17,10 +17,10 @@ dependencies {
     testImplementation("dev.zacsweers.kctfork:ksp:0.12.1")
     testImplementation("io.kotest:kotest-assertions-core:6.1.11")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-    implementation("com.google.devtools.ksp:symbol-processing-api:2.3.8")
+    implementation("com.google.devtools.ksp:symbol-processing-api:2.3.9")
 
     // kotlin-logging dependency for generated code compatibility
-    compileOnly("io.github.oshai:kotlin-logging-jvm:8.0.03")
+    compileOnly("io.github.oshai:kotlin-logging-jvm:8.0.4")
 }
 
 tasks.test {

--- a/workload/build.gradle.kts
+++ b/workload/build.gradle.kts
@@ -19,8 +19,8 @@ dependencies {
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
     // Kotlin logging dependencies
-    implementation("io.github.oshai:kotlin-logging-jvm:8.0.03")
-    implementation("ch.qos.logback:logback-classic:1.5.32")
+    implementation("io.github.oshai:kotlin-logging-jvm:8.0.4")
+    implementation("ch.qos.logback:logback-classic:1.5.33")
 
     // Access AutoLog annotation in source code
     compileOnly(project(":processor"))


### PR DESCRIPTION
## Summary

Consolidates all pending Renovate dependency updates into a single PR.

- `com.google.devtools.ksp`: 2.3.8 → 2.3.9 (`build.gradle.kts`, `processor/build.gradle.kts`)
- `io.github.oshai:kotlin-logging-jvm`: 8.0.03 → 8.0.4 (`processor/build.gradle.kts`, `workload/build.gradle.kts`)
- `ch.qos.logback:logback-classic`: 1.5.32 → 1.5.33 (`workload/build.gradle.kts`)

Closes #4

## Test plan

- [x] `./gradlew build` passes successfully with all updated dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)