### PR TITLE
fix(deps): bump low-risk dependencies within Kotlin 2.3 line

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ import org.jlleitschuh.gradle.ktlint.KtlintExtension
 
 plugins {
     kotlin("jvm") version "2.3.21" apply false
-    id("com.google.devtools.ksp") version "2.3.9" apply false
+    id("com.google.devtools.ksp") version "2.3.10" apply false
     id("com.vanniktech.maven.publish") version "0.37.0" apply false
     id("org.jlleitschuh.gradle.ktlint") version "14.2.0"
 }

--- a/processor/build.gradle.kts
+++ b/processor/build.gradle.kts
@@ -11,13 +11,13 @@ repositories {
 }
 
 dependencies {
-    testImplementation(platform("org.junit:junit-bom:6.1.0"))
+    testImplementation(platform("org.junit:junit-bom:6.1.2"))
     testImplementation("org.junit.jupiter:junit-jupiter")
     // Maintained fork of kotlin-compile-testing
     testImplementation("dev.zacsweers.kctfork:ksp:0.13.0")
-    testImplementation("io.kotest:kotest-assertions-core:6.2.1")
+    testImplementation("io.kotest:kotest-assertions-core:6.2.2")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-    implementation("com.google.devtools.ksp:symbol-processing-api:2.3.9")
+    implementation("com.google.devtools.ksp:symbol-processing-api:2.3.10")
 
     // kotlin-logging dependency for generated code compatibility
     compileOnly("io.github.oshai:kotlin-logging-jvm:8.0.4")

--- a/workload/build.gradle.kts
+++ b/workload/build.gradle.kts
@@ -13,14 +13,14 @@ repositories {
 }
 
 dependencies {
-    testImplementation(platform("org.junit:junit-bom:6.1.0"))
+    testImplementation(platform("org.junit:junit-bom:6.1.2"))
     testImplementation("org.junit.jupiter:junit-jupiter")
-    testImplementation("io.kotest:kotest-assertions-core:6.2.1")
+    testImplementation("io.kotest:kotest-assertions-core:6.2.2")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
     // Kotlin logging dependencies
     implementation("io.github.oshai:kotlin-logging-jvm:8.0.4")
-    implementation("ch.qos.logback:logback-classic:1.5.37")
+    implementation("ch.qos.logback:logback-classic:1.5.38")
 
     // Access AutoLog annotation in source code
     compileOnly(project(":processor"))


### PR DESCRIPTION
## Summary

Resolves the **low-risk** dependency updates tracked in the Renovate Dependency Dashboard (#4). All bumps stay within the current **Kotlin 2.3.x** line, so there is no compiler/KSP coupling risk.

| Dependency | From | To |
|------------|------|----|
| `ch.qos.logback:logback-classic` | 1.5.37 | 1.5.38 |
| `io.kotest:kotest-assertions-core` | 6.2.1 | 6.2.2 |
| `org.junit:junit-bom` | 6.1.0 | 6.1.2 |
| `com.google.devtools.ksp` | 2.3.9 | 2.3.10 |

This consolidates Renovate PRs #126, #127, #128, and #129 into one change.

## Why Kotlin 2.4.0 is excluded

The dashboard also lists Kotlin `2.3.21 → 2.4.0` (#130). KSP versions are pinned to the Kotlin version, so bumping Kotlin to 2.4.0 requires a **matching KSP 2.4.0-x** rather than 2.3.10. That is a larger, coupled change and should land in its own PR with a full build check — kept out of this one deliberately.

## Verification

`./gradlew clean build` — BUILD SUCCESSFUL, all processor + workload tests pass.

Closes: none (the Dependency Dashboard issue stays open by design; Renovate maintains it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)