### PR TITLE
Release v2.3.2

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -28,7 +28,7 @@ body:
     attributes:
       label: Library Version
       description: Which version of kotlin-logging-extensions are you using?
-      placeholder: "e.g., 2.3.1"
+      placeholder: "e.g., 2.3.2"
     validations:
       required: true
 
@@ -46,7 +46,7 @@ body:
     attributes:
       label: KSP Version
       description: Which KSP version are you using?
-      placeholder: "e.g., 2.3.8"
+      placeholder: "e.g., 2.3.10"
     validations:
       required: true
 
@@ -55,7 +55,7 @@ body:
     attributes:
       label: kotlin-logging Version
       description: Which kotlin-logging dependency are you using?
-      placeholder: "e.g., io.github.oshai:kotlin-logging-jvm:8.0.02"
+      placeholder: "e.g., io.github.oshai:kotlin-logging-jvm:8.0.4"
     validations:
       required: true
 
@@ -108,12 +108,12 @@ body:
       placeholder: |
         plugins {
             kotlin("jvm") version "2.3.21"
-            id("com.google.devtools.ksp") version "2.3.4"
+            id("com.google.devtools.ksp") version "2.3.10"
         }
 
         dependencies {
-            ksp("io.github.doljae:kotlin-logging-extensions:2.3.1")
-            implementation("io.github.doljae:kotlin-logging-extensions:2.3.1")
+            ksp("io.github.doljae:kotlin-logging-extensions:2.3.2")
+            implementation("io.github.doljae:kotlin-logging-extensions:2.3.2")
             implementation("io.github.oshai:kotlin-logging-jvm:7.0.7")
         }
     validations:

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -46,7 +46,7 @@ body:
     attributes:
       label: Library Version
       description: Which version of kotlin-logging-extensions are you using?
-      placeholder: "e.g., 2.3.1"
+      placeholder: "e.g., 2.3.2"
     validations:
       required: false
 
@@ -55,7 +55,7 @@ body:
     attributes:
       label: kotlin-logging Version
       description: Which kotlin-logging dependency are you using?
-      placeholder: "e.g., io.github.oshai:kotlin-logging-jvm:8.0.02"
+      placeholder: "e.g., io.github.oshai:kotlin-logging-jvm:8.0.4"
     validations:
       required: false
 

--- a/.github/ISSUE_TEMPLATE/version_compatibility.yml
+++ b/.github/ISSUE_TEMPLATE/version_compatibility.yml
@@ -15,7 +15,7 @@ body:
     attributes:
       label: kotlin-logging-extensions Version
       description: Which version are you using?
-      placeholder: "e.g., 2.3.1"
+      placeholder: "e.g., 2.3.2"
     validations:
       required: true
 
@@ -33,7 +33,7 @@ body:
     attributes:
       label: Your KSP Version
       description: Which KSP version are you using?
-      placeholder: "e.g., 2.3.8"
+      placeholder: "e.g., 2.3.10"
     validations:
       required: true
 
@@ -42,7 +42,7 @@ body:
     attributes:
       label: Your kotlin-logging Version
       description: Which kotlin-logging dependency are you using?
-      placeholder: "e.g., io.github.oshai:kotlin-logging-jvm:8.0.02"
+      placeholder: "e.g., io.github.oshai:kotlin-logging-jvm:8.0.4"
     validations:
       required: true
 

--- a/.github/actions/extract-versions/action.yml
+++ b/.github/actions/extract-versions/action.yml
@@ -13,6 +13,9 @@ outputs:
   logback_version:
     description: 'Logback version'
     value: ${{ steps.extract.outputs.logback_version }}
+  kotlin_logging_dependency:
+    description: 'Full kotlin-logging-jvm dependency coordinate'
+    value: ${{ steps.extract.outputs.kotlin_logging_dependency }}
 
 runs:
   using: "composite"
@@ -32,4 +35,5 @@ runs:
         echo "ksp_version=$KSP_VERSION" >> $GITHUB_OUTPUT
         echo "kotlin_logging_version=$KOTLIN_LOGGING_VERSION" >> $GITHUB_OUTPUT
         echo "logback_version=$LOGBACK_VERSION" >> $GITHUB_OUTPUT
+        echo "kotlin_logging_dependency=io.github.oshai:kotlin-logging-jvm:$KOTLIN_LOGGING_VERSION" >> $GITHUB_OUTPUT
       shell: bash

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -254,12 +254,12 @@ jobs:
             # Badge updates
             (r'https://img\.shields\.io/badge/kotlin-[0-9]+\.[0-9]+\.[0-9]+-blue\.svg', f'https://img.shields.io/badge/kotlin-{KOTLIN_VERSION}-blue.svg'),
             (r'https://img\.shields\.io/badge/kotlin--logging-[^-]*-green\.svg', 'https://img.shields.io/badge/kotlin--logging-5.0.0+-green.svg'),
-            (r'https://img\.shields\.io/badge/KSP-[0-9]+\.[0-9]+\.[0-9]+--[0-9]+\.[0-9]+\.[0-9]+-purple\.svg', f'https://img.shields.io/badge/KSP-{KSP_VERSION.replace("-", "--")}-purple.svg'),
+            (r'https://img\.shields\.io/badge/KSP-[0-9]+\.[0-9]+\.[0-9]+(--[0-9]+\.[0-9]+\.[0-9]+)?-purple\.svg', f'https://img.shields.io/badge/KSP-{KSP_VERSION.replace("-", "--")}-purple.svg'),
             
             # Dependency examples
             (r'io\.github\.doljae:kotlin-logging-extensions:[0-9]+\.[0-9]+\.[0-9]+(-[0-9]+\.[0-9]+\.[0-9]+)?', f'io.github.doljae:kotlin-logging-extensions:{VERSION}'),
             (r'kotlin\("jvm"\) version "[0-9]+\.[0-9]+\.[0-9]+"', f'kotlin("jvm") version "{KOTLIN_VERSION}"'),
-            (r'id\("com\.google\.devtools\.ksp"\) version "[0-9]+\.[0-9]+\.[0-9]+-[0-9]+\.[0-9]+\.[0-9]+"', f'id("com.google.devtools.ksp") version "{KSP_VERSION}"'),
+            (r'id\("com\.google\.devtools\.ksp"\) version "[0-9]+\.[0-9]+\.[0-9]+(-[0-9]+\.[0-9]+\.[0-9]+)?"', f'id("com.google.devtools.ksp") version "{KSP_VERSION}"'),
             
             # Version compatibility section
             (r'// For Kotlin [0-9]+\.[0-9]+\.[0-9]+ projects:', f'// For Kotlin {KOTLIN_VERSION} projects:'),
@@ -298,7 +298,7 @@ jobs:
             ('bug_report.yml', [
                 (r'io\.github\.doljae:kotlin-logging-extensions:[0-9]+\.[0-9]+\.[0-9]+(-[0-9]+\.[0-9]+\.[0-9]+)?', f'io.github.doljae:kotlin-logging-extensions:{VERSION}'),
                 (r'kotlin\("jvm"\) version "[0-9]+\.[0-9]+\.[0-9]+"', f'kotlin("jvm") version "{KOTLIN_VERSION}"'),
-                (r'id\("com\.google\.devtools\.ksp"\) version "[0-9]+\.[0-9]+\.[0-9]+-[0-9]+\.[0-9]+\.[0-9]+"', f'id("com.google.devtools.ksp") version "{KSP_VERSION}"'),
+                (r'id\("com\.google\.devtools\.ksp"\) version "[0-9]+\.[0-9]+\.[0-9]+(-[0-9]+\.[0-9]+\.[0-9]+)?"', f'id("com.google.devtools.ksp") version "{KSP_VERSION}"'),
                 (r'ch\.qos\.logback:logback-classic:[0-9]+\.[0-9]+\.[0-9]+', f'ch.qos.logback:logback-classic:{LOGBACK_VERSION}'),
                 (r'placeholder: "e\.g\., [^"]*"', f'placeholder: "e.g., {VERSION}"', 1),  # First occurrence
                 (r'placeholder: "e\.g\., [^"]*"', f'placeholder: "e.g., {KOTLIN_VERSION}"', 2),  # Second occurrence
@@ -412,7 +412,7 @@ jobs:
       id: release_notes
       run: |
         # Get the previous tag
-        PREVIOUS_TAG=$(git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+-[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+        PREVIOUS_TAG=$(git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9]+\.[0-9]+\.[0-9]+)?$' | head -1)
         CURRENT_VERSION="${{ needs.validate.outputs.version }}"
         
         echo "Generating release notes since ${PREVIOUS_TAG}"

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -262,7 +262,8 @@ jobs:
             (r'id\("com\.google\.devtools\.ksp"\) version "[0-9]+\.[0-9]+\.[0-9]+(-[0-9]+\.[0-9]+\.[0-9]+)?"', f'id("com.google.devtools.ksp") version "{KSP_VERSION}"'),
             
             # Version compatibility section
-            (r'// For Kotlin [0-9]+\.[0-9]+\.[0-9]+ projects:', f'// For Kotlin {KOTLIN_VERSION} projects:'),
+            # Refers to the Kotlin minor line (e.g. 2.3.x), not the exact build version
+            (r'// For Kotlin [0-9]+\.[0-9]+\.(x|[0-9]+) projects:', f'// For Kotlin {".".join(KOTLIN_VERSION.split(".")[:2])}.x projects:'),
             
             # kotlin-logging version
             (r'io\.github\.oshai:kotlin-logging-jvm:[0-9]+\.[0-9]+\.[0-9]+', f'io.github.oshai:kotlin-logging-jvm:{KOTLIN_LOGGING_VERSION}'),

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Kotlin](https://img.shields.io/badge/kotlin-2.3.21-blue.svg?logo=kotlin)](http://kotlinlang.org)
 [![kotlin-logging](https://img.shields.io/badge/kotlin--logging-5.0.0+-green.svg)](https://github.com/oshai/kotlin-logging)
-[![KSP](https://img.shields.io/badge/KSP-2.3.4-purple.svg)](https://github.com/google/ksp)
+[![KSP](https://img.shields.io/badge/KSP-2.3.10-purple.svg)](https://github.com/google/ksp)
 
 **Elegant [kotlin-logging](https://github.com/oshai/kotlin-logging) extensions for zero-boilerplate logger generation in
 Kotlin classes using [KSP](https://github.com/google/ksp)**
@@ -48,7 +48,7 @@ Add to your `build.gradle.kts`:
 ```kotlin
 plugins {
     kotlin("jvm") version "2.3.21"
-    id("com.google.devtools.ksp") version "2.3.4"
+    id("com.google.devtools.ksp") version "2.3.10"
 }
 
 repositories {
@@ -56,10 +56,10 @@ repositories {
 }
 
 dependencies {
-    compileOnly("io.github.doljae:kotlin-logging-extensions:2.3.1") // for @AutoLog
-    ksp("io.github.doljae:kotlin-logging-extensions:2.3.1")
-    implementation("io.github.oshai:kotlin-logging-jvm:8.0.02")
-    implementation("ch.qos.logback:logback-classic:1.5.32") // Logger implementation required
+    compileOnly("io.github.doljae:kotlin-logging-extensions:2.3.2") // for @AutoLog
+    ksp("io.github.doljae:kotlin-logging-extensions:2.3.2")
+    implementation("io.github.oshai:kotlin-logging-jvm:8.0.4")
+    implementation("ch.qos.logback:logback-classic:1.6.0") // Logger implementation required
 }
 
 // Optional: enable PackageScan mode (see below for details)
@@ -163,6 +163,7 @@ your Kotlin line; use the KSP version shown next to it.
 
 | Library        | Kotlin   | KSP            |
 |----------------|----------|----------------|
+| `2.3.2` | `2.3.21` | `2.3.10` |
 | `2.3.1` | `2.3.21` | `2.3.8` |
 | `2.3.0`        | `2.3.0+` | `2.3.4+`       |
 | `2.2.21-0.0.6` | `2.2.21` | `2.2.21-2.0.4` |
@@ -186,13 +187,13 @@ your Kotlin line; use the KSP version shown next to it.
 // For Kotlin 2.3.x projects:
 plugins {
     kotlin("jvm") version "2.3.21"
-    id("com.google.devtools.ksp") version "2.3.4"
+    id("com.google.devtools.ksp") version "2.3.10"
 }
 
 dependencies {
-    compileOnly("io.github.doljae:kotlin-logging-extensions:2.3.1")
-    ksp("io.github.doljae:kotlin-logging-extensions:2.3.1")
-    implementation("io.github.oshai:kotlin-logging-jvm:8.0.02") // 5.0.0+
+    compileOnly("io.github.doljae:kotlin-logging-extensions:2.3.2")
+    ksp("io.github.doljae:kotlin-logging-extensions:2.3.2")
+    implementation("io.github.oshai:kotlin-logging-jvm:8.0.4") // 5.0.0+
 }
 ```
 
@@ -210,7 +211,7 @@ or [Log4j2](https://logging.apache.org/log4j/2.x/).
 ```kotlin
 plugins {
     kotlin("jvm") version "2.3.21"
-    id("com.google.devtools.ksp") version "2.3.4"
+    id("com.google.devtools.ksp") version "2.3.10"
 }
 
 repositories {
@@ -218,10 +219,10 @@ repositories {
 }
 
 dependencies {
-    compileOnly("io.github.doljae:kotlin-logging-extensions:2.3.1")
-    ksp("io.github.doljae:kotlin-logging-extensions:2.3.1")
-    implementation("io.github.oshai:kotlin-logging-jvm:8.0.02")
-    implementation("ch.qos.logback:logback-classic:1.5.32")
+    compileOnly("io.github.doljae:kotlin-logging-extensions:2.3.2")
+    ksp("io.github.doljae:kotlin-logging-extensions:2.3.2")
+    implementation("io.github.oshai:kotlin-logging-jvm:8.0.4")
+    implementation("ch.qos.logback:logback-classic:1.6.0")
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -154,8 +154,12 @@ That's it! The logger is generated using the fully qualified class name as the l
 
 ## 📋 Version Compatibility
 
-**Choose the library version that matches your project's KSP version.** Starting from version 2.3.0, we follow KSP's
-independent versioning policy.
+**Choose the library version whose `Kotlin` column matches your project's Kotlin version.**
+
+Since [KSP 2.3.0](https://github.com/google/ksp/releases/tag/2.3.0), the KSP version is no longer tied to the Kotlin
+compiler version — KSP2 is a standalone tool built on the stable compiler APIs rather than a compiler plugin. This is
+why a single KSP version (`2.3.10`) serves both the Kotlin 2.3.x and 2.4.x lines. Pick the library release built for
+your Kotlin line; use the KSP version shown next to it.
 
 | Library        | Kotlin   | KSP            |
 |----------------|----------|----------------|
@@ -175,11 +179,11 @@ independent versioning policy.
 ### How to Use
 
 1. **Check your Kotlin version** in `build.gradle.kts`
-2. **Pick the matching library version** from the table above
-3. **Use the exact KSP version** shown in the table
+2. **Pick the library version whose `Kotlin` column matches your line** from the table above
+3. **Use the KSP version** shown next to it
 
 ```kotlin
-// For Kotlin 2.3.0+ projects:
+// For Kotlin 2.3.x projects:
 plugins {
     kotlin("jvm") version "2.3.21"
     id("com.google.devtools.ksp") version "2.3.4"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ import org.jlleitschuh.gradle.ktlint.KtlintExtension
 
 plugins {
     kotlin("jvm") version "2.3.21" apply false
-    id("com.google.devtools.ksp") version "2.3.9" apply false
+    id("com.google.devtools.ksp") version "2.3.10" apply false
     id("com.vanniktech.maven.publish") version "0.37.0" apply false
     id("org.jlleitschuh.gradle.ktlint") version "14.2.0"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ ksp.useKSP2=true
 
 # Project information
 project.group=io.github.doljae
-project.version=2.3.1
+project.version=2.3.2
 project.artifactId=kotlin-logging-extensions
 project.description=Kotlin Logging Extensions
 project.url=https://github.com/doljae/kotlin-logging-extensions

--- a/processor/build.gradle.kts
+++ b/processor/build.gradle.kts
@@ -11,13 +11,13 @@ repositories {
 }
 
 dependencies {
-    testImplementation(platform("org.junit:junit-bom:6.1.0"))
+    testImplementation(platform("org.junit:junit-bom:6.1.2"))
     testImplementation("org.junit.jupiter:junit-jupiter")
     // Maintained fork of kotlin-compile-testing
     testImplementation("dev.zacsweers.kctfork:ksp:0.13.0")
-    testImplementation("io.kotest:kotest-assertions-core:6.2.1")
+    testImplementation("io.kotest:kotest-assertions-core:6.2.2")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-    implementation("com.google.devtools.ksp:symbol-processing-api:2.3.9")
+    implementation("com.google.devtools.ksp:symbol-processing-api:2.3.10")
 
     // kotlin-logging dependency for generated code compatibility
     compileOnly("io.github.oshai:kotlin-logging-jvm:8.0.4")

--- a/processor/build.gradle.kts
+++ b/processor/build.gradle.kts
@@ -15,7 +15,7 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter")
     // Maintained fork of kotlin-compile-testing
     testImplementation("dev.zacsweers.kctfork:ksp:0.13.0")
-    testImplementation("io.kotest:kotest-assertions-core:6.2.2")
+    testImplementation("io.kotest:kotest-assertions-core:6.2.3")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     implementation("com.google.devtools.ksp:symbol-processing-api:2.3.10")
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -29,9 +29,9 @@ print_error() {
 # Function to validate version format
 validate_version() {
     local version=$1
-    if [[ ! $version =~ ^[0-9]+\.[0-9]+\.[0-9]+-[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-        print_error "Version must be in KSP format: KOTLIN_VERSION-LIB_VERSION"
-        print_error "Example: 2.1.21-0.0.1 (Kotlin 2.1.21, Library version 0.0.1)"
+    # SemVer (current, e.g. 2.3.2) or legacy KOTLIN-LIB format (e.g. 2.2.21-0.0.6)
+    if [[ ! $version =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9]+\.[0-9]+\.[0-9]+)?$ ]]; then
+        print_error "Version must be SemVer (e.g. 2.3.2) or legacy KOTLIN_VERSION-LIB_VERSION (e.g. 2.2.21-0.0.6)"
         exit 1
     fi
 }
@@ -89,35 +89,35 @@ check_github_cli() {
 
 # Function to suggest next version
 suggest_next_version() {
-    local latest_tag=$(git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+-[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
-    
+    local latest_tag=$(git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
+    local build_kotlin=$(grep 'kotlin("jvm") version' build.gradle.kts | sed 's/.*version "\([^"]*\)".*/\1/')
+
     if [[ -z $latest_tag ]]; then
         echo
-        print_info "No previous releases found"
-        print_info "Suggested first version: 2.1.21-0.0.1 (current Kotlin version + initial lib version)"
+        print_info "No SemVer releases found"
+        print_info "Suggested first version: ${build_kotlin%.*}.0"
         echo
         return
     fi
-    
+
     local version=${latest_tag#v}
-    local kotlin_version=${version%-*}
-    local lib_version=${version#*-}
-    
     local IFS='.'
-    read -ra LIB_PARTS <<< "$lib_version"
-    local lib_major=${LIB_PARTS[0]}
-    local lib_minor=${LIB_PARTS[1]}
-    local lib_patch=${LIB_PARTS[2]}
-    
+    read -ra PARTS <<< "$version"
+    local major=${PARTS[0]}
+    local minor=${PARTS[1]}
+    local patch=${PARTS[2]}
+    unset IFS
+
     echo
     print_info "Current latest version: $version"
-    print_info "Kotlin version: $kotlin_version, Library version: $lib_version"
+    print_info "build.gradle.kts Kotlin version: $build_kotlin"
     print_info ""
     print_info "Suggestions:"
-    print_info "  Patch (bug fixes): $kotlin_version-$lib_major.$lib_minor.$((lib_patch + 1))"
-    print_info "  Minor (new features): $kotlin_version-$lib_major.$((lib_minor + 1)).0"
-    print_info "  Major (breaking changes): $kotlin_version-$((lib_major + 1)).0.0"
-    print_info "  Kotlin upgrade: 2.1.21-$lib_version (if Kotlin version changed)"
+    print_info "  Patch (deps, fixes): $major.$minor.$((patch + 1))"
+    # A Kotlin minor-line bump starts a new library minor line, e.g. Kotlin 2.4.x -> 2.4.0
+    if [[ "${build_kotlin%.*}" != "$major.$minor" ]]; then
+        print_info "  Kotlin ${build_kotlin} line: ${build_kotlin%.*}.0"
+    fi
     echo
 }
 
@@ -177,7 +177,7 @@ main() {
     if tag_exists "$tag"; then
         print_error "Tag $tag already exists."
         print_info "Existing tags:"
-        git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+-[0-9]+\.[0-9]+\.[0-9]+$' | head -5
+        git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9]+\.[0-9]+\.[0-9]+)?$' | head -5
         exit 1
     fi
     

--- a/workload/build.gradle.kts
+++ b/workload/build.gradle.kts
@@ -15,12 +15,12 @@ repositories {
 dependencies {
     testImplementation(platform("org.junit:junit-bom:6.1.2"))
     testImplementation("org.junit.jupiter:junit-jupiter")
-    testImplementation("io.kotest:kotest-assertions-core:6.2.2")
+    testImplementation("io.kotest:kotest-assertions-core:6.2.3")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
     // Kotlin logging dependencies
     implementation("io.github.oshai:kotlin-logging-jvm:8.0.4")
-    implementation("ch.qos.logback:logback-classic:1.5.38")
+    implementation("ch.qos.logback:logback-classic:1.6.0")
 
     // Access AutoLog annotation in source code
     compileOnly(project(":processor"))

--- a/workload/build.gradle.kts
+++ b/workload/build.gradle.kts
@@ -13,14 +13,14 @@ repositories {
 }
 
 dependencies {
-    testImplementation(platform("org.junit:junit-bom:6.1.0"))
+    testImplementation(platform("org.junit:junit-bom:6.1.2"))
     testImplementation("org.junit.jupiter:junit-jupiter")
-    testImplementation("io.kotest:kotest-assertions-core:6.2.1")
+    testImplementation("io.kotest:kotest-assertions-core:6.2.2")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
     // Kotlin logging dependencies
     implementation("io.github.oshai:kotlin-logging-jvm:8.0.4")
-    implementation("ch.qos.logback:logback-classic:1.5.37")
+    implementation("ch.qos.logback:logback-classic:1.5.38")
 
     // Access AutoLog annotation in source code
     compileOnly(project(":processor"))


### PR DESCRIPTION
## 🚀 Release v2.3.2

Prepares the release of `2.3.2` on the **Kotlin 2.3 line**. Kotlin stays at `2.3.21`; the Kotlin 2.4 bump is a separate release (see the follow-up PR).

`2.3.2` was never published — Maven Central's latest is `2.3.1` — so this reuses the number rather than skipping it. Supersedes #118, which was branched from `e794641` back on 2026-05-30 and had gone stale.

### 📦 Dependencies
- `io.kotest:kotest-assertions-core` 6.2.2 → **6.2.3**
- `ch.qos.logback:logback-classic` 1.5.38 → **1.6.0**

logback 1.6.0 is a major bump but upstream documents it as a drop-in replacement for 1.5.x: it removes previously deprecated APIs, needs JDK 11+ at runtime (build targets toolchain 21) and moves optional components to `jakarta.*`. It is used only by the `workload` verification module and is never published, so consumers are unaffected.

Everything else was already current: junit-bom 6.1.2, kctfork 0.13.0, kotlin-logging 8.0.4, ktlint 1.8.0 / 14.2.0, vanniktech 0.37.0, Gradle 9.6.1.

### 🔧 Release tooling fixes
The automation still assumed the pre-2.3.0 `KOTLIN-LIB` version format and was failing **silently**:

- `scripts/release.sh` rejected SemVer outright — `2.3.2` could not be released through the script at all. Its suggestions also scanned only legacy tags, so it reported "no previous releases".
- The README badge and KSP-example regexes only matched the old `X.Y.Z-A.B.C` KSP format. Since KSP moved to plain SemVer they never matched — which is why the badge still advertised **KSP 2.3.4** while the build had been on 2.3.10. This PR is the first time those update correctly.
- Release-note generation picked the previous tag from legacy tags only, so this changelog would otherwise have spanned back to `v2.2.21-0.0.6` (exactly what #118 shows).
- `extract-versions` referenced `kotlin_logging_dependency` but never declared or emitted it, leaving issue-template placeholders blank.

### 📚 Documentation
The compatibility section told users to match the library to their **KSP** version. That no longer describes reality: as of [KSP 2.3.0](https://github.com/google/ksp/releases/tag/2.3.0) the KSP version is independent of the Kotlin compiler version, because KSP2 is a standalone tool on the stable compiler APIs rather than a compiler plugin. One KSP version now spans several Kotlin lines. Users are now directed to match on their **Kotlin** version.

### ⚡ Version Compatibility
- **Kotlin**: 2.3.21
- **KSP**: 2.3.10
- **kotlin-logging**: 5.0.0+

### ✅ Verification
`./gradlew clean build ktlintCheck test` passes locally.

### 🔄 After Merge
- Tag `v2.3.2`, GitHub Release, publish to Maven Central.
- Renovate PRs #127 (kotest 6.2.3) and #128 (logback 1.6.0) become redundant and should close automatically.

### ✅ Review Checklist
- [ ] Version number is correct
- [ ] All version references are updated consistently
- [ ] Tests are passing
- [ ] Ready to release
