### PR TITLE
Release v2.4.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -28,7 +28,7 @@ body:
     attributes:
       label: Library Version
       description: Which version of kotlin-logging-extensions are you using?
-      placeholder: "e.g., 2.3.2"
+      placeholder: "e.g., 2.4.0"
     validations:
       required: true
 
@@ -37,7 +37,7 @@ body:
     attributes:
       label: Kotlin Version
       description: Which Kotlin version are you using?
-      placeholder: "e.g., 2.3.21"
+      placeholder: "e.g., 2.4.10"
     validations:
       required: true
 
@@ -107,13 +107,13 @@ body:
       render: kotlin
       placeholder: |
         plugins {
-            kotlin("jvm") version "2.3.21"
+            kotlin("jvm") version "2.4.10"
             id("com.google.devtools.ksp") version "2.3.10"
         }
 
         dependencies {
-            ksp("io.github.doljae:kotlin-logging-extensions:2.3.2")
-            implementation("io.github.doljae:kotlin-logging-extensions:2.3.2")
+            ksp("io.github.doljae:kotlin-logging-extensions:2.4.0")
+            implementation("io.github.doljae:kotlin-logging-extensions:2.4.0")
             implementation("io.github.oshai:kotlin-logging-jvm:7.0.7")
         }
     validations:

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -46,7 +46,7 @@ body:
     attributes:
       label: Library Version
       description: Which version of kotlin-logging-extensions are you using?
-      placeholder: "e.g., 2.3.2"
+      placeholder: "e.g., 2.4.0"
     validations:
       required: false
 

--- a/.github/ISSUE_TEMPLATE/version_compatibility.yml
+++ b/.github/ISSUE_TEMPLATE/version_compatibility.yml
@@ -15,7 +15,7 @@ body:
     attributes:
       label: kotlin-logging-extensions Version
       description: Which version are you using?
-      placeholder: "e.g., 2.3.2"
+      placeholder: "e.g., 2.4.0"
     validations:
       required: true
 
@@ -24,7 +24,7 @@ body:
     attributes:
       label: Your Kotlin Version
       description: Which Kotlin version are you using?
-      placeholder: "e.g., 2.3.21"
+      placeholder: "e.g., 2.4.10"
     validations:
       required: true
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![CI](https://github.com/doljae/kotlin-logging-extensions/actions/workflows/ci.yml/badge.svg)](https://github.com/doljae/kotlin-logging-extensions/actions/workflows/ci.yml)
 [![Maven Central](https://img.shields.io/maven-central/v/io.github.doljae/kotlin-logging-extensions.svg?label=Maven%20Central)](https://central.sonatype.com/artifact/io.github.doljae/kotlin-logging-extensions)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Kotlin](https://img.shields.io/badge/kotlin-2.3.21-blue.svg?logo=kotlin)](http://kotlinlang.org)
+[![Kotlin](https://img.shields.io/badge/kotlin-2.4.10-blue.svg?logo=kotlin)](http://kotlinlang.org)
 [![kotlin-logging](https://img.shields.io/badge/kotlin--logging-5.0.0+-green.svg)](https://github.com/oshai/kotlin-logging)
 [![KSP](https://img.shields.io/badge/KSP-2.3.10-purple.svg)](https://github.com/google/ksp)
 
@@ -47,7 +47,7 @@ Add to your `build.gradle.kts`:
 
 ```kotlin
 plugins {
-    kotlin("jvm") version "2.3.21"
+    kotlin("jvm") version "2.4.10"
     id("com.google.devtools.ksp") version "2.3.10"
 }
 
@@ -56,8 +56,8 @@ repositories {
 }
 
 dependencies {
-    compileOnly("io.github.doljae:kotlin-logging-extensions:2.3.2") // for @AutoLog
-    ksp("io.github.doljae:kotlin-logging-extensions:2.3.2")
+    compileOnly("io.github.doljae:kotlin-logging-extensions:2.4.0") // for @AutoLog
+    ksp("io.github.doljae:kotlin-logging-extensions:2.4.0")
     implementation("io.github.oshai:kotlin-logging-jvm:8.0.4")
     implementation("ch.qos.logback:logback-classic:1.6.0") // Logger implementation required
 }
@@ -163,6 +163,7 @@ your Kotlin line; use the KSP version shown next to it.
 
 | Library        | Kotlin   | KSP            |
 |----------------|----------|----------------|
+| `2.4.0` | `2.4.10` | `2.3.10` |
 | `2.3.2` | `2.3.21` | `2.3.10` |
 | `2.3.1` | `2.3.21` | `2.3.8` |
 | `2.3.0`        | `2.3.0+` | `2.3.4+`       |
@@ -184,15 +185,15 @@ your Kotlin line; use the KSP version shown next to it.
 3. **Use the KSP version** shown next to it
 
 ```kotlin
-// For Kotlin 2.3.x projects:
+// For Kotlin 2.4.x projects:
 plugins {
-    kotlin("jvm") version "2.3.21"
+    kotlin("jvm") version "2.4.10"
     id("com.google.devtools.ksp") version "2.3.10"
 }
 
 dependencies {
-    compileOnly("io.github.doljae:kotlin-logging-extensions:2.3.2")
-    ksp("io.github.doljae:kotlin-logging-extensions:2.3.2")
+    compileOnly("io.github.doljae:kotlin-logging-extensions:2.4.0")
+    ksp("io.github.doljae:kotlin-logging-extensions:2.4.0")
     implementation("io.github.oshai:kotlin-logging-jvm:8.0.4") // 5.0.0+
 }
 ```
@@ -210,7 +211,7 @@ or [Log4j2](https://logging.apache.org/log4j/2.x/).
 
 ```kotlin
 plugins {
-    kotlin("jvm") version "2.3.21"
+    kotlin("jvm") version "2.4.10"
     id("com.google.devtools.ksp") version "2.3.10"
 }
 
@@ -219,8 +220,8 @@ repositories {
 }
 
 dependencies {
-    compileOnly("io.github.doljae:kotlin-logging-extensions:2.3.2")
-    ksp("io.github.doljae:kotlin-logging-extensions:2.3.2")
+    compileOnly("io.github.doljae:kotlin-logging-extensions:2.4.0")
+    ksp("io.github.doljae:kotlin-logging-extensions:2.4.0")
     implementation("io.github.oshai:kotlin-logging-jvm:8.0.4")
     implementation("ch.qos.logback:logback-classic:1.6.0")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import org.gradle.kotlin.dsl.configure
 import org.jlleitschuh.gradle.ktlint.KtlintExtension
 
 plugins {
-    kotlin("jvm") version "2.3.21" apply false
+    kotlin("jvm") version "2.4.10" apply false
     id("com.google.devtools.ksp") version "2.3.10" apply false
     id("com.vanniktech.maven.publish") version "0.37.0" apply false
     id("org.jlleitschuh.gradle.ktlint") version "14.2.0"

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ ksp.useKSP2=true
 
 # Project information
 project.group=io.github.doljae
-project.version=2.3.2
+project.version=2.4.0
 project.artifactId=kotlin-logging-extensions
 project.description=Kotlin Logging Extensions
 project.url=https://github.com/doljae/kotlin-logging-extensions


### PR DESCRIPTION
> ⚠️ **Merge #135 first, and release v2.3.2 before merging this PR.**
>
> #133 merged, but its release **failed to publish** ([run 30143923725](https://github.com/doljae/kotlin-logging-extensions/actions/runs/30143923725)) — v2.3.2 is not tagged and not on Maven Central. #135 fixes the publish job. Merging this PR beforehand would set `gradle.properties` to 2.4.0 and make the v2.3.2 retry publish the wrong version.

Adds support for the **Kotlin 2.4 line**: bumps the build to Kotlin `2.4.10` while keeping KSP at `2.3.10`.

### 🔑 Why no KSP 2.4.x

Since [KSP 2.3.0](https://github.com/google/ksp/releases/tag/2.3.0) the KSP version is **no longer tied to the Kotlin compiler version** — KSP2 is a standalone tool built on the stable compiler APIs (the ones IntelliJ and Android Lint use) rather than a compiler plugin, so it does not need rebuilding per Kotlin release. Maven Central shows the break cleanly: `…2.2.21-2.0.5`, then `2.3.0`, `2.3.1`, … `2.3.10`.

There is therefore no KSP 2.4.x to wait for. The note on 001260b claiming Kotlin 2.4 "requires a matching KSP 2.4.0-x" was mistaken; the official [KSP setup docs](https://kotlinlang.org/docs/ksp-quickstart.html) pair Kotlin 2.4.10 with KSP 2.3.10.

### ⚠️ KSP 2.3.10 is the minimum for Kotlin 2.4

Kotlin 2.4.0 standardized default module names to `{group}:{project_name}`, and the colon broke KSP code generation on **2.3.9 and earlier** ([google/ksp#2964](https://github.com/google/ksp/issues/2964)). The fix shipped in KSP 2.3.10, which #133 already puts in place.

### ⚡ Version Compatibility
- **Kotlin**: 2.4.10
- **KSP**: 2.3.10
- **kotlin-logging**: 5.0.0+

Kotlin 2.3.x users stay on `2.3.2`. Because main will sit at Kotlin 2.4.10 after this merges, any future 2.3.x patch needs a `2.3.x` maintenance branch — `create-release-pr.yml` already accepts a `base_branch` input for this, but nothing creates that branch automatically.

### ✅ Verification
Verified locally on Kotlin 2.4.10:
- `./gradlew clean build ktlintCheck test` passes with **no version-compatibility warnings**
- The `workload` module's generated extensions are produced as expected
- A throwaway Kotlin **2.3.21** project compiles cleanly against a **2.4.10**-built processor jar, and a 2.3.21 compiler accepts stdlib 2.4.10 — so the metadata/stdlib jump is not disruptive in either direction

### 🔄 After Merge
- Tag `v2.4.0`, GitHub Release, publish to Maven Central.
- Renovate PR #132 (Kotlin 2.4.10) becomes redundant and should close automatically.

### ✅ Review Checklist
- [ ] #133 merged first
- [ ] Version number is correct
- [ ] All version references are updated consistently
- [ ] Tests are passing
- [ ] Ready to release
