### PR TITLE
fix(ci): restore signed Maven Central upload and GitHub Packages credentials

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -13,6 +13,15 @@ on:
       - '.github/ISSUE_TEMPLATE/**'
       - '.github/workflows/**'
   workflow_dispatch:
+    inputs:
+      force:
+        description: |
+          Release the version currently in gradle.properties, ignoring the
+          commit-message check. Use to retry a release whose publish step
+          failed after the release commit already landed on the branch.
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: write
@@ -37,7 +46,12 @@ jobs:
       id: check
       run: |
         LAST_COMMIT_MSG=$(git log -1 --pretty=format:"%s")
-        if [[ $LAST_COMMIT_MSG =~ ^Release\ v[0-9]+\.[0-9]+\.[0-9]+(-[0-9]+\.[0-9]+\.[0-9]+)?\ \(\#([0-9]+)\)$ ]]; then
+        if [[ "${{ github.event.inputs.force }}" == "true" ]]; then
+          # Manual retry: the release commit may already be several commits back,
+          # so fall back to whatever version gradle.properties currently declares.
+          echo "is-release=true" >> $GITHUB_OUTPUT
+          echo "pr_number=" >> $GITHUB_OUTPUT
+        elif [[ $LAST_COMMIT_MSG =~ ^Release\ v[0-9]+\.[0-9]+\.[0-9]+(-[0-9]+\.[0-9]+\.[0-9]+)?\ \(\#([0-9]+)\)$ ]]; then
           echo "is-release=true" >> $GITHUB_OUTPUT
           echo "pr_number=${BASH_REMATCH[2]}" >> $GITHUB_OUTPUT
         elif [[ $LAST_COMMIT_MSG =~ ^chore:\ update\ version\ references\ to\ [0-9]+\.[0-9]+\.[0-9]+(-[0-9]+\.[0-9]+\.[0-9]+)?$ ]]; then
@@ -78,15 +92,23 @@ jobs:
         fetch-depth: 0
     - name: Setup Gradle
       uses: ./.github/actions/setup-gradle
-    - name: Publish
+    # These two publications must stay in separate steps. processor/build.gradle.kts
+    # only calls signAllPublications() when GITHUB_TOKEN is absent, so exporting that
+    # token here would silently upload unsigned artifacts to Maven Central.
+    - name: Upload to Maven Central Staging
       env:
         ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
         ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
         ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.SIGNING_KEY }}
         ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.SIGNING_PASSWORD }}
+      run: |
+        ./gradlew publishToMavenCentral --no-configuration-cache
+    - name: Publish to GitHub Packages
+      env:
+        GITHUB_USERNAME: ${{ github.actor }}
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        ./gradlew publishToMavenCentral publishAllPublicationsToGithubPackagesRepository --no-configuration-cache
+        ./gradlew publishAllPublicationsToGithubPackagesRepository --no-configuration-cache
 
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Why the v2.3.2 release failed

[Run 30143923725](https://github.com/doljae/kotlin-logging-extensions/actions/runs/30143923725) failed at `publish`, so no tag was created and nothing reached Maven Central.

```
> Task :processor:publishMavenPublicationToGithubPackagesRepository FAILED
property 'credentials.username' doesn't have a configured value
```

Both causes trace to 7db2012, which collapsed the previously separate Maven Central and GitHub Packages publish steps into one. v2.3.2 is the first release attempted since, so it is the first to hit them.

### 1. Missing `GITHUB_USERNAME` (visible failure)
`processor/build.gradle.kts` reads `System.getenv("GITHUB_USERNAME")` for the githubPackages repository credentials. The merged step never sets it. At v2.3.1 the GitHub Packages step passed `GITHUB_USERNAME: \${{ github.actor }}`.

### 2. Unsigned Maven Central upload (silent failure)
`processor/build.gradle.kts` guards signing on the *absence* of `GITHUB_TOKEN`:

```kotlin
// Only sign when publishing to Maven Central, not for GitHub Packages
if (System.getenv("GITHUB_TOKEN") == null) {
    signAllPublications()
}
```

The merged step exports `GITHUB_TOKEN` for *both* publications, so signing was skipped and the Central upload went out **unsigned**. The Gradle task still reported success — this only surfaces when the Central Portal rejects the deployment at validation.

The step separation was load-bearing, exactly as that comment describes.

## Changes

- Split `publish` back into **Upload to Maven Central Staging** (signing secrets, no `GITHUB_TOKEN`) and **Publish to GitHub Packages** (`GITHUB_USERNAME` + `GITHUB_TOKEN`), matching the v2.3.1 shape. Added a comment so they are not merged again.
- Added a `force` input to `workflow_dispatch`. Once a release commit lands on main, a failed publish currently leaves **no way to retry**: pushing a fix does not re-trigger the workflow (`paths-ignore` excludes `.github/workflows/**`), and a manual dispatch evaluated the commit-message check against the newest commit and skipped everything. `force` releases whatever version `gradle.properties` declares.

## Verified
- Workflow YAML parses; `publish` now has 4 steps.
- `check-release` logic simulated under bash across `force` on/off and all three commit-message shapes — matches intent, and the existing non-forced behaviour is unchanged.

## ⚠️ Before retrying v2.3.2
The failed run may have left an **unsigned deployment** for 2.3.2 in the Sonatype Central Portal. Check the Deployments page and drop it if present, otherwise the retry can conflict.

Merging this PR does **not** trigger a release (`paths-ignore` covers workflow files). To release 2.3.2 afterwards, run **Auto Release** manually on `main` with `force = true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)