### PR TITLE
feat: remove @GenerateLogger

### DIFF
--- a/processor/src/main/kotlin/io/github/doljae/kotlinlogging/extensions/GenerateLogger.kt
+++ b/processor/src/main/kotlin/io/github/doljae/kotlinlogging/extensions/GenerateLogger.kt
@@ -1,9 +1,0 @@
-package io.github.doljae.kotlinlogging.extensions
-
-@Deprecated(
-    message = "Use @AutoLog instead.",
-    replaceWith = ReplaceWith("AutoLog"),
-)
-@Target(AnnotationTarget.CLASS)
-@Retention(AnnotationRetention.SOURCE)
-public annotation class GenerateLogger

--- a/processor/src/main/kotlin/io/github/doljae/kotlinlogging/extensions/LoggerProcessor.kt
+++ b/processor/src/main/kotlin/io/github/doljae/kotlinlogging/extensions/LoggerProcessor.kt
@@ -69,7 +69,7 @@ class LoggerProcessor(
 
     private fun KSClassDeclaration.hasLoggerGenerationAnnotation(): Boolean {
         return annotations.any { annotation ->
-            annotation.annotationType.resolve().declaration.qualifiedName?.asString() in LOGGER_GENERATION_ANNOTATIONS
+            annotation.annotationType.resolve().declaration.qualifiedName?.asString() == LOGGER_GENERATION_ANNOTATION
         }
     }
 
@@ -304,11 +304,7 @@ class LoggerProcessor(
 
         /** Base name of the per-package generated file. */
         public const val GENERATED_FILE_NAME: String = "KotlinLoggingExtensions"
-        private val LOGGER_GENERATION_ANNOTATIONS =
-            setOf(
-                "io.github.doljae.kotlinlogging.extensions.AutoLog",
-                "io.github.doljae.kotlinlogging.extensions.GenerateLogger",
-            )
+        private const val LOGGER_GENERATION_ANNOTATION = "io.github.doljae.kotlinlogging.extensions.AutoLog"
 
         // Ref: https://kotlinlang.org/docs/keyword-reference.html
         private val hardKeywords =

--- a/processor/src/main/kotlin/io/github/doljae/kotlinlogging/extensions/LoggerProcessorProvider.kt
+++ b/processor/src/main/kotlin/io/github/doljae/kotlinlogging/extensions/LoggerProcessorProvider.kt
@@ -14,7 +14,7 @@ class LoggerProcessorProvider : SymbolProcessorProvider {
         if (generationMode == LoggerGenerationMode.PACKAGE_SCAN && packageScanTargetPatterns.isEmpty()) {
             environment.logger.warn(
                 "Package scan mode is enabled but no valid targets were configured. " +
-                    "Only classes annotated with @AutoLog (or deprecated @GenerateLogger) will get log extensions.",
+                    "Only classes annotated with @AutoLog will get log extensions.",
             )
         }
 

--- a/processor/src/test/kotlin/io/github/doljae/kotlinlogging/extensions/LoggerProcessorTest.kt
+++ b/processor/src/test/kotlin/io/github/doljae/kotlinlogging/extensions/LoggerProcessorTest.kt
@@ -730,36 +730,6 @@ class LoggerProcessorTest {
     }
 
     @Test
-    fun `should support deprecated GenerateLogger annotation for backward compatibility`() {
-        val source =
-            SourceFile.kotlin(
-                "LegacyAnnotationClass.kt",
-                """
-                package com.example
-                import io.github.doljae.kotlinlogging.extensions.GenerateLogger
-
-                @GenerateLogger
-                class LegacyAnnotationClass
-                """.trimIndent(),
-            )
-
-        val compilation =
-            KotlinCompilation().apply {
-                sources = listOf(source)
-                configureKsp {
-                    symbolProcessorProviders += LoggerProcessorProvider()
-                }
-                inheritClassPath = true
-            }
-
-        compilation.compile()
-
-        val generatedFile = compilation.generatedExtensionsFileContaining("LegacyAnnotationClass")
-
-        generatedFile?.exists() shouldBe true
-    }
-
-    @Test
     fun `should generate for every class when nothing is configured`() {
         val source =
             SourceFile.kotlin(


### PR DESCRIPTION
Closes #144

`@GenerateLogger` was created in `5bc443d` already carrying `@Deprecated`, and no released version ever exposed it — `git log -S"GenerateLogger" --all` finds no commit before that one containing the string. No user code can reference it, so its deprecation protected nobody and the alias only added a second name to keep in sync.

## Changes

- Delete the `GenerateLogger` annotation
- Collapse the trigger-annotation set to a single constant (`LOGGER_GENERATION_ANNOTATION`)
- Drop the `(or deprecated @GenerateLogger)` fragment from the no-valid-targets warning
- Remove the backward-compatibility note from the README
- Remove the test covering the alias

## Notes

There is no deprecation cycle to observe here because there is no population to migrate. Release notes should still explain why a deprecated symbol disappears without the usual grace period, so the removal does not read as a compatibility violation.

This PR is independent of the #142 / #137 stack and can merge in any order.

## Verification

`./gradlew clean build` (includes ktlint) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)