### PR TITLE
feat(processor): warn when a top-level log is shadowed by the generated extension

### DIFF
--- a/processor/src/main/kotlin/io/github/doljae/kotlinlogging/extensions/LoggerProcessor.kt
+++ b/processor/src/main/kotlin/io/github/doljae/kotlinlogging/extensions/LoggerProcessor.kt
@@ -103,11 +103,42 @@ class LoggerProcessor(
             ?: false
     }
 
+    /**
+     * A generated `log` extension wins over a top-level `log` in the same file: inside the class the
+     * implicit receiver sits at an inner scope level than the file scope, so the extension is found
+     * first and the top-level property is never reached. This is silent — no ambiguity, no warning
+     * from the compiler — so report it here.
+     *
+     * Generation is still correct and must not be skipped: top-level functions in the same file have
+     * no implicit receiver and keep resolving to the top-level property, so a top-level `log` is not a
+     * signal that the file's classes want no logger.
+     */
+    private fun warnIfTopLevelLogIsShadowed(classDeclaration: KSClassDeclaration) {
+        val hasTopLevelLog =
+            classDeclaration.containingFile
+                ?.declarations
+                ?.filterIsInstance<KSPropertyDeclaration>()
+                ?.any { property -> property.simpleName.asString() == "log" }
+                ?: false
+
+        if (!hasTopLevelLog) return
+
+        logger.warn(
+            "Top-level 'log' in this file is shadowed inside ${classDeclaration.simpleName.asString()}: " +
+                "'log' there resolves to the generated extension, not the top-level property. " +
+                "Rename one of them if that is not intended.",
+            classDeclaration,
+        )
+    }
+
     private fun generateLogger(classDeclaration: KSClassDeclaration) {
         if (classDeclaration.qualifiedName == null) return
         if (classDeclaration.classKind == ClassKind.ENUM_ENTRY) return
 
         val visibility = getVisibilityModifier(classDeclaration) ?: return
+
+        warnIfTopLevelLogIsShadowed(classDeclaration)
+
         val receiverDeclaration = buildReceiverDeclaration(classDeclaration)
         
         val rawPackageName = classDeclaration.packageName.asString()

--- a/processor/src/test/kotlin/io/github/doljae/kotlinlogging/extensions/LoggerProcessorTest.kt
+++ b/processor/src/test/kotlin/io/github/doljae/kotlinlogging/extensions/LoggerProcessorTest.kt
@@ -824,4 +824,71 @@ class LoggerProcessorTest {
 
         generatedFile?.exists() shouldBe true
     }
+
+    @Test
+    fun `should warn but still generate when a top-level log is shadowed`() {
+        val source =
+            SourceFile.kotlin(
+                "ShadowedClass.kt",
+                """
+                package com.example
+                import io.github.doljae.kotlinlogging.extensions.AutoLog
+                import io.github.oshai.kotlinlogging.KotlinLogging
+
+                val log = KotlinLogging.logger("TOP_LEVEL")
+
+                @AutoLog
+                class ShadowedClass
+                """.trimIndent(),
+            )
+
+        val compilation =
+            KotlinCompilation().apply {
+                sources = listOf(source)
+                configureKsp {
+                    symbolProcessorProviders += LoggerProcessorProvider()
+                }
+                inheritClassPath = true
+            }
+
+        val result = compilation.compile()
+
+        val generatedFile =
+            compilation.kspSourcesDir.walkTopDown().find {
+                it.name == "ShadowedClassKotlinLoggingExtensions.kt"
+            }
+
+        // Generation must not be skipped: top-level functions in the file still resolve to the
+        // top-level property, so its presence is not a signal to leave the class without a logger.
+        generatedFile?.exists() shouldBe true
+        result.messages shouldContain "Top-level 'log' in this file is shadowed inside ShadowedClass"
+    }
+
+    @Test
+    fun `should not warn about shadowing when the file has no top-level log`() {
+        val source =
+            SourceFile.kotlin(
+                "UnshadowedClass.kt",
+                """
+                package com.example
+                import io.github.doljae.kotlinlogging.extensions.AutoLog
+
+                @AutoLog
+                class UnshadowedClass
+                """.trimIndent(),
+            )
+
+        val compilation =
+            KotlinCompilation().apply {
+                sources = listOf(source)
+                configureKsp {
+                    symbolProcessorProviders += LoggerProcessorProvider()
+                }
+                inheritClassPath = true
+            }
+
+        val result = compilation.compile()
+
+        result.messages shouldNotContain "is shadowed inside"
+    }
 }


### PR DESCRIPTION
Closes #142

A generated `log` extension silently wins over a top-level `log` in the same file. Verified by bytecode:

```kotlin
package examples.scratch

val log = KotlinLogging.logger("TOP_LEVEL")

@AutoLog
class ShadowProbe {
    fun fromClass(): String = log.name
}

fun fromTopLevelFunction(): String = log.name
```

| Call site | Resolves to |
|---|---|
| `ShadowProbe.fromClass()` | `ShadowProbeKotlinLoggingExtensionsKt.getLog(ShadowProbe)` — the generated extension |
| `fromTopLevelFunction()` | `getstatic Field log` — the top-level property |

Inside the class the implicit receiver sits at an inner scope level than the file scope, so the extension is found first and the top-level property is never reached. The two candidates never compete at the same level, which is why the compiler reports no ambiguity — the author's own logger goes unused with no signal beyond an unexpected logger name in the output.

## Why generation is not skipped

The table above shows the two coexist correctly: top-level functions have no implicit receiver and keep resolving to the top-level property. A top-level `log` is therefore usually meant for the file's top-level functions, not a signal that its classes want no logger. Skipping generation would take `log` away from those classes and turn a silent shadow into a compile error.

This differs from the existing `hasDeclaredLogProperty()` skip, where a `log` on the class itself or its companion expresses a clear, local intent.

## Notes

- The warning is not gated on generation mode — the shadowing is identical in annotation and package-scan mode, and annotating a class does not imply the author knows about the interaction.
- Projects using `allWarningsAsErrors` will fail on this warning, which is why the condition is narrow: it fires only where shadowing actually occurs.
- Passing the symbol to `logger.warn` attaches file and line information, so it is clickable in the IDE.

## Verification

`./gradlew clean build` (includes ktlint) passes. Two tests added: one asserting the warning fires *and* generation still happens, one asserting no warning when the file has no top-level `log`. Confirmed non-vacuous — removing the call makes only the positive test fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)