### PR TITLE
feat(processor): generate one file per package instead of one file per class

### DIFF
--- a/processor/src/main/kotlin/io/github/doljae/kotlinlogging/extensions/LoggerProcessor.kt
+++ b/processor/src/main/kotlin/io/github/doljae/kotlinlogging/extensions/LoggerProcessor.kt
@@ -10,6 +10,7 @@ import com.google.devtools.ksp.symbol.ClassKind
 import com.google.devtools.ksp.symbol.KSAnnotated
 import com.google.devtools.ksp.symbol.KSClassDeclaration
 import com.google.devtools.ksp.symbol.KSDeclaration
+import com.google.devtools.ksp.symbol.KSFile
 import com.google.devtools.ksp.symbol.KSPropertyDeclaration
 import com.google.devtools.ksp.symbol.Visibility
 import io.github.doljae.common.StringUtility.wrapReservedWords
@@ -20,6 +21,14 @@ class LoggerProcessor(
     private val generationMode: LoggerGenerationMode = LoggerGenerationMode.ANNOTATION_ONLY,
     private val packageScanTargetPatterns: Set<String> = emptySet(),
 ) : SymbolProcessor {
+    /**
+     * Counts how many files have already been written for a package. A package is normally written
+     * once, but [process] may run over several rounds, and [CodeGenerator.createNewFile] cannot write
+     * the same path twice. A package seen again in a later round therefore gets a numbered file rather
+     * than losing its extensions.
+     */
+    private val writtenFilesPerPackage = mutableMapOf<String, Int>()
+
     override fun process(resolver: Resolver): List<KSAnnotated> {
         val classes =
             resolver
@@ -36,9 +45,13 @@ class LoggerProcessor(
                     classDeclaration.hasDeclaredLogProperty()
                 }
 
-        classes.forEach { classDeclaration ->
-            generateLogger(classDeclaration)
-        }
+        classes
+            .mapNotNull { classDeclaration -> buildExtension(classDeclaration) }
+            .groupBy { extension -> extension.packageName }
+            .toSortedMap()
+            .forEach { (packageName, extensions) ->
+                writePackageFile(packageName, extensions)
+            }
 
         return emptyList()
     }
@@ -131,54 +144,88 @@ class LoggerProcessor(
         )
     }
 
-    private fun generateLogger(classDeclaration: KSClassDeclaration) {
-        if (classDeclaration.qualifiedName == null) return
-        if (classDeclaration.classKind == ClassKind.ENUM_ENTRY) return
+    private fun buildExtension(classDeclaration: KSClassDeclaration): LoggerExtension? {
+        val qualifiedName = classDeclaration.qualifiedName?.asString() ?: return null
+        if (classDeclaration.classKind == ClassKind.ENUM_ENTRY) return null
 
-        val visibility = getVisibilityModifier(classDeclaration) ?: return
+        val visibility = getVisibilityModifier(classDeclaration) ?: return null
+        val containingFile = classDeclaration.containingFile ?: return null
 
         warnIfTopLevelLogIsShadowed(classDeclaration)
 
         val receiverDeclaration = buildReceiverDeclaration(classDeclaration)
-        
-        val rawPackageName = classDeclaration.packageName.asString()
-        val qualifiedName = classDeclaration.qualifiedName!!.asString()
-        val className = if (rawPackageName.isEmpty()) {
-            qualifiedName
-        } else {
-            qualifiedName.substring(rawPackageName.length + 1)
-        }
-        
-        val fileName = "${className.replace('.', '_')}KotlinLoggingExtensions"
 
-        val safePackageName = wrapReservedWords(
-            target = rawPackageName,
-            delimiter = '.',
-            reservedWords = hardKeywords,
-            quoteChar = '`',
+        return LoggerExtension(
+            packageName = classDeclaration.packageName.asString(),
+            qualifiedName = qualifiedName,
+            containingFile = containingFile,
+            declaration =
+                """
+                ${visibility}val ${receiverDeclaration.typeParameters}${receiverDeclaration.receiverType}.log: KLogger
+                    get() = KotlinLogging.logger("$qualifiedName")
+                """.trimIndent(),
         )
+    }
 
-        val loggerCode =
-            """
-            package $safePackageName
-            
-            import io.github.oshai.kotlinlogging.KLogger
-            import io.github.oshai.kotlinlogging.KotlinLogging
-            
-            ${visibility}val ${receiverDeclaration.typeParameters}${receiverDeclaration.receiverType}.log: KLogger
-                get() = KotlinLogging.logger("$qualifiedName")
-            """.trimIndent()
+    /**
+     * Writes every extension of a package into a single file. The extension must live in the target
+     * class's own package so that `log` resolves without an import, and a Kotlin file declares exactly
+     * one package — so one file per package is the smallest number of files reachable without forcing
+     * users to add imports.
+     */
+    private fun writePackageFile(packageName: String, extensions: List<LoggerExtension>) {
+        // Sorted so that identical sources always produce byte-identical output.
+        val sortedExtensions = extensions.sortedBy { extension -> extension.qualifiedName }
+
+        val safePackageName =
+            wrapReservedWords(
+                target = packageName,
+                delimiter = '.',
+                reservedWords = hardKeywords,
+                quoteChar = '`',
+            )
+
+        val fileContent =
+            buildString {
+                if (safePackageName.isNotEmpty()) {
+                    appendLine("package $safePackageName")
+                    appendLine()
+                }
+                appendLine("import io.github.oshai.kotlinlogging.KLogger")
+                appendLine("import io.github.oshai.kotlinlogging.KotlinLogging")
+                sortedExtensions.forEach { extension ->
+                    appendLine()
+                    appendLine(extension.declaration)
+                }
+            }.trimEnd()
+
+        val writeCount = writtenFilesPerPackage.merge(packageName, 1, Int::plus)!!
+        val fileName =
+            if (writeCount == 1) GENERATED_FILE_NAME else "$GENERATED_FILE_NAME$writeCount"
 
         codeGenerator
             .createNewFile(
-                Dependencies(false, classDeclaration.containingFile!!),
-                rawPackageName,
+                // Aggregating: this file holds extensions from every source file in the package, so any
+                // source change must regenerate it. An isolating dependency would drop the entries of
+                // files that were not themselves reprocessed.
+                Dependencies(
+                    aggregating = true,
+                    sources = sortedExtensions.map { it.containingFile }.distinct().toTypedArray(),
+                ),
+                packageName,
                 fileName,
             ).bufferedWriter()
             .use { writer ->
-                writer.write(loggerCode)
+                writer.write(fileContent)
             }
     }
+
+    private data class LoggerExtension(
+        val packageName: String,
+        val qualifiedName: String,
+        val containingFile: KSFile,
+        val declaration: String,
+    )
 
     private fun getVisibilityModifier(classDeclaration: KSClassDeclaration): String? {
         var current: KSDeclaration? = classDeclaration
@@ -250,6 +297,9 @@ class LoggerProcessor(
         public const val PACKAGE_SCAN_TARGETS_OPTION_KEY: String = "kotlinloggingextensions.targets"
         public const val LEGACY_PACKAGE_PREFIXES_OPTION_KEY: String =
             "kotlinloggingextensions.autoGeneratePackagePrefixes"
+
+        /** Base name of the per-package generated file. */
+        public const val GENERATED_FILE_NAME: String = "KotlinLoggingExtensions"
         private val LOGGER_GENERATION_ANNOTATIONS =
             setOf(
                 "io.github.doljae.kotlinlogging.extensions.AutoLog",

--- a/processor/src/test/kotlin/io/github/doljae/kotlinlogging/extensions/GeneratedSources.kt
+++ b/processor/src/test/kotlin/io/github/doljae/kotlinlogging/extensions/GeneratedSources.kt
@@ -1,0 +1,33 @@
+package io.github.doljae.kotlinlogging.extensions
+
+import com.tschuchort.compiletesting.KotlinCompilation
+import com.tschuchort.compiletesting.kspSourcesDir
+import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
+import java.io.File
+
+/**
+ * Finds the generated file holding the `log` extension for [receiverType], or `null` when no
+ * extension was generated for it.
+ *
+ * Extensions are grouped one file per package, so a file's name no longer identifies the class it
+ * belongs to. Tests therefore locate it by the declaration it must contain, which asserts the same
+ * thing the old per-class file name did: this class either got an extension or it did not.
+ *
+ * [receiverType] is the receiver as it appears in the generated source — `SimpleClass`,
+ * `Outer.Nested`, `GenericClass<T>`.
+ */
+@OptIn(ExperimentalCompilerApi::class)
+internal fun KotlinCompilation.generatedExtensionsFileContaining(receiverType: String): File? {
+    return generatedExtensionsFiles()
+        .find { file -> file.readText().contains("val $receiverType.log: KLogger") }
+}
+
+/** Every file the processor generated, in stable path order. */
+@OptIn(ExperimentalCompilerApi::class)
+internal fun KotlinCompilation.generatedExtensionsFiles(): List<File> {
+    return kspSourcesDir
+        .walkTopDown()
+        .filter { file -> file.isFile && file.extension == "kt" }
+        .sortedBy { file -> file.path }
+        .toList()
+}

--- a/processor/src/test/kotlin/io/github/doljae/kotlinlogging/extensions/InnerClassSupportTest.kt
+++ b/processor/src/test/kotlin/io/github/doljae/kotlinlogging/extensions/InnerClassSupportTest.kt
@@ -40,10 +40,8 @@ class InnerClassSupportTest {
         val result = compilation.compile()
         // result.exitCode shouldBe KotlinCompilation.ExitCode.OK
 
-        // We expect a file for Nested class with unique name
-        val files = compilation.kspSourcesDir.walkTopDown().toList()
-        val generatedFile = files.find { it.name == "Outer_NestedKotlinLoggingExtensions.kt" }
-        
+        val generatedFile = compilation.generatedExtensionsFileContaining("Outer.Nested")
+
         generatedFile?.exists() shouldBe true
         
         val content = generatedFile?.readText() ?: ""
@@ -80,10 +78,7 @@ class InnerClassSupportTest {
 
         compilation.compile()
 
-        val generatedFile =
-            compilation.kspSourcesDir.walkTopDown().find {
-                it.name == "Outer_NestedKotlinLoggingExtensions.kt"
-            }
+        val generatedFile = compilation.generatedExtensionsFileContaining("<T, U> Outer<T>.Nested<U>")
 
         generatedFile?.exists() shouldBe true
         val content = generatedFile?.readText() ?: ""

--- a/processor/src/test/kotlin/io/github/doljae/kotlinlogging/extensions/LoggerProcessorTest.kt
+++ b/processor/src/test/kotlin/io/github/doljae/kotlinlogging/extensions/LoggerProcessorTest.kt
@@ -5,6 +5,7 @@ import com.tschuchort.compiletesting.SourceFile
 import com.tschuchort.compiletesting.configureKsp
 import com.tschuchort.compiletesting.kspProcessorOptions
 import com.tschuchort.compiletesting.kspSourcesDir
+import io.kotest.matchers.ints.shouldBeLessThan
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotContain
@@ -52,10 +53,7 @@ class LoggerProcessorTest {
         compilation.kspSourcesDir.walkTopDown().forEach { println(it.absolutePath) }
 
         // Verify that the file was generated
-        val generatedFile = 
-            compilation.kspSourcesDir.walkTopDown().find {
-                it.name == "SimpleClassKotlinLoggingExtensions.kt"
-            }
+        val generatedFile = compilation.generatedExtensionsFileContaining("SimpleClass")
 
         generatedFile?.exists() shouldBe true
         generatedFile?.readText() shouldContain "val SimpleClass.log: KLogger"
@@ -88,10 +86,7 @@ class LoggerProcessorTest {
         val result = compilation.compile()
         // result.exitCode shouldBe KotlinCompilation.ExitCode.OK
 
-        val generatedFile = 
-            compilation.kspSourcesDir.walkTopDown().find {
-                it.name == "DeepClassKotlinLoggingExtensions.kt"
-            }
+        val generatedFile = compilation.generatedExtensionsFileContaining("DeepClass")
 
         generatedFile?.exists() shouldBe true
         generatedFile?.readText() shouldContain "package com.example.deeply.nested"
@@ -124,10 +119,7 @@ class LoggerProcessorTest {
 
         compilation.compile()
 
-        val generatedFile =
-            compilation.kspSourcesDir.walkTopDown().find {
-                it.name == "GenericClassKotlinLoggingExtensions.kt"
-            }
+        val generatedFile = compilation.generatedExtensionsFileContaining("<T> GenericClass<T>")
 
         generatedFile?.exists() shouldBe true
         generatedFile?.readText() shouldContain "val <T> GenericClass<T>.log: KLogger"
@@ -162,14 +154,8 @@ class LoggerProcessorTest {
         val result = compilation.compile()
         // result.exitCode shouldBe KotlinCompilation.ExitCode.OK
 
-        val generatedFileA = 
-            compilation.kspSourcesDir.walkTopDown().find {
-                it.name == "ClassAKotlinLoggingExtensions.kt"
-            }
-        val generatedFileB = 
-            compilation.kspSourcesDir.walkTopDown().find {
-                it.name == "ClassBKotlinLoggingExtensions.kt"
-            }
+        val generatedFileA = compilation.generatedExtensionsFileContaining("ClassA")
+        val generatedFileB = compilation.generatedExtensionsFileContaining("ClassB")
 
         generatedFileA?.exists() shouldBe true
         generatedFileB?.exists() shouldBe true
@@ -204,10 +190,7 @@ class LoggerProcessorTest {
         val result = compilation.compile()
         // result.exitCode shouldBe KotlinCompilation.ExitCode.OK
 
-        val generatedFile = 
-            compilation.kspSourcesDir.walkTopDown().find {
-                it.name == "ReservedClassKotlinLoggingExtensions.kt"
-            }
+        val generatedFile = compilation.generatedExtensionsFileContaining("ReservedClass")
 
         generatedFile?.exists() shouldBe true
         generatedFile?.readText() shouldContain "package com.example.`fun`"
@@ -238,10 +221,7 @@ class LoggerProcessorTest {
 
         compilation.compile()
 
-        val generatedFile =
-            compilation.kspSourcesDir.walkTopDown().find {
-                it.name == "NoAnnotationClassKotlinLoggingExtensions.kt"
-            }
+        val generatedFile = compilation.generatedExtensionsFileContaining("NoAnnotationClass")
 
         generatedFile shouldBe null
     }
@@ -275,10 +255,7 @@ class LoggerProcessorTest {
 
         compilation.compile()
 
-        val generatedFile =
-            compilation.kspSourcesDir.walkTopDown().find {
-                it.name == "ClassWithLogPropertyKotlinLoggingExtensions.kt"
-            }
+        val generatedFile = compilation.generatedExtensionsFileContaining("ClassWithLogProperty")
 
         generatedFile shouldBe null
     }
@@ -314,10 +291,7 @@ class LoggerProcessorTest {
 
         compilation.compile()
 
-        val generatedFile =
-            compilation.kspSourcesDir.walkTopDown().find {
-                it.name == "ClassWithCompanionLogPropertyKotlinLoggingExtensions.kt"
-            }
+        val generatedFile = compilation.generatedExtensionsFileContaining("ClassWithCompanionLogProperty")
 
         generatedFile shouldBe null
     }
@@ -350,10 +324,7 @@ class LoggerProcessorTest {
 
         compilation.compile()
 
-        val generatedFile =
-            compilation.kspSourcesDir.walkTopDown().find {
-                it.name == "PackageScopedClassKotlinLoggingExtensions.kt"
-            }
+        val generatedFile = compilation.generatedExtensionsFileContaining("PackageScopedClass")
 
         generatedFile?.exists() shouldBe true
         generatedFile?.readText() shouldContain "val PackageScopedClass.log: KLogger"
@@ -388,10 +359,7 @@ class LoggerProcessorTest {
 
         compilation.compile()
 
-        val generatedFile =
-            compilation.kspSourcesDir.walkTopDown().find {
-                it.name == "OutsidePackageClassKotlinLoggingExtensions.kt"
-            }
+        val generatedFile = compilation.generatedExtensionsFileContaining("OutsidePackageClass")
 
         generatedFile shouldBe null
     }
@@ -426,10 +394,7 @@ class LoggerProcessorTest {
 
         compilation.compile()
 
-        val generatedFile =
-            compilation.kspSourcesDir.walkTopDown().find {
-                it.name == "AnnotatedOutsidePackageClassKotlinLoggingExtensions.kt"
-            }
+        val generatedFile = compilation.generatedExtensionsFileContaining("AnnotatedOutsidePackageClass")
 
         generatedFile?.exists() shouldBe true
         generatedFile?.readText() shouldContain "val AnnotatedOutsidePackageClass.log: KLogger"
@@ -463,10 +428,7 @@ class LoggerProcessorTest {
 
         val result = compilation.compile()
 
-        val generatedFile =
-            compilation.kspSourcesDir.walkTopDown().find {
-                it.name == "ModeIgnoredClassKotlinLoggingExtensions.kt"
-            }
+        val generatedFile = compilation.generatedExtensionsFileContaining("ModeIgnoredClass")
 
         generatedFile?.exists() shouldBe true
         result.messages shouldContain "Package scan targets take precedence and PackageScan mode will be used"
@@ -500,10 +462,7 @@ class LoggerProcessorTest {
 
         val result = compilation.compile()
 
-        val generatedFile =
-            compilation.kspSourcesDir.walkTopDown().find {
-                it.name == "InvalidTargetsWithAnnotationOnlyModeClassKotlinLoggingExtensions.kt"
-            }
+        val generatedFile = compilation.generatedExtensionsFileContaining("InvalidTargetsWithAnnotationOnlyModeClass")
 
         generatedFile shouldBe null
         result.messages shouldContain "Ignoring invalid package target 'invalid*pattern'"
@@ -538,10 +497,7 @@ class LoggerProcessorTest {
 
         val result = compilation.compile()
 
-        val generatedFile =
-            compilation.kspSourcesDir.walkTopDown().find {
-                it.name == "UnsupportedModeClassKotlinLoggingExtensions.kt"
-            }
+        val generatedFile = compilation.generatedExtensionsFileContaining("UnsupportedModeClass")
 
         generatedFile shouldBe null
         result.messages shouldContain "Unsupported value 'NotSupported'"
@@ -576,10 +532,7 @@ class LoggerProcessorTest {
 
         compilation.compile()
 
-        val generatedFile =
-            compilation.kspSourcesDir.walkTopDown().find {
-                it.name == "NormalizedModeClassKotlinLoggingExtensions.kt"
-            }
+        val generatedFile = compilation.generatedExtensionsFileContaining("NormalizedModeClass")
 
         generatedFile?.exists() shouldBe true
     }
@@ -611,10 +564,7 @@ class LoggerProcessorTest {
 
         compilation.compile()
 
-        val generatedFile =
-            compilation.kspSourcesDir.walkTopDown().find {
-                it.name == "AnnotationOnlyModeClassKotlinLoggingExtensions.kt"
-            }
+        val generatedFile = compilation.generatedExtensionsFileContaining("AnnotationOnlyModeClass")
 
         generatedFile shouldBe null
     }
@@ -656,14 +606,8 @@ class LoggerProcessorTest {
 
         compilation.compile()
 
-        val exactPackageGeneratedFile =
-            compilation.kspSourcesDir.walkTopDown().find {
-                it.name == "ExactPackageClassKotlinLoggingExtensions.kt"
-            }
-        val subPackageGeneratedFile =
-            compilation.kspSourcesDir.walkTopDown().find {
-                it.name == "SubPackageClassKotlinLoggingExtensions.kt"
-            }
+        val exactPackageGeneratedFile = compilation.generatedExtensionsFileContaining("ExactPackageClass")
+        val subPackageGeneratedFile = compilation.generatedExtensionsFileContaining("SubPackageClass")
 
         exactPackageGeneratedFile?.exists() shouldBe true
         subPackageGeneratedFile shouldBe null
@@ -696,10 +640,7 @@ class LoggerProcessorTest {
 
         compilation.compile()
 
-        val generatedFile =
-            compilation.kspSourcesDir.walkTopDown().find {
-                it.name == "LegacyOptionClassKotlinLoggingExtensions.kt"
-            }
+        val generatedFile = compilation.generatedExtensionsFileContaining("LegacyOptionClass")
 
         generatedFile?.exists() shouldBe true
     }
@@ -741,14 +682,8 @@ class LoggerProcessorTest {
 
         compilation.compile()
 
-        val normalizedGeneratedFile =
-            compilation.kspSourcesDir.walkTopDown().find {
-                it.name == "NormalizedTargetClassKotlinLoggingExtensions.kt"
-            }
-        val invalidGeneratedFile =
-            compilation.kspSourcesDir.walkTopDown().find {
-                it.name == "InvalidTargetClassKotlinLoggingExtensions.kt"
-            }
+        val normalizedGeneratedFile = compilation.generatedExtensionsFileContaining("NormalizedTargetClass")
+        val invalidGeneratedFile = compilation.generatedExtensionsFileContaining("InvalidTargetClass")
 
         normalizedGeneratedFile?.exists() shouldBe true
         invalidGeneratedFile shouldBe null
@@ -782,10 +717,7 @@ class LoggerProcessorTest {
 
         val result = compilation.compile()
 
-        val generatedFile =
-            compilation.kspSourcesDir.walkTopDown().find {
-                it.name == "NoValidTargetClassKotlinLoggingExtensions.kt"
-            }
+        val generatedFile = compilation.generatedExtensionsFileContaining("NoValidTargetClass")
 
         generatedFile shouldBe null
         result.messages shouldContain "Ignoring invalid package target 'invalid*pattern'"
@@ -817,12 +749,82 @@ class LoggerProcessorTest {
 
         compilation.compile()
 
-        val generatedFile =
-            compilation.kspSourcesDir.walkTopDown().find {
-                it.name == "LegacyAnnotationClassKotlinLoggingExtensions.kt"
-            }
+        val generatedFile = compilation.generatedExtensionsFileContaining("LegacyAnnotationClass")
 
         generatedFile?.exists() shouldBe true
+    }
+
+    @Test
+    fun `should emit one file per package regardless of how many classes it holds`() {
+        val sources =
+            listOf(
+                SourceFile.kotlin(
+                    "ServiceClasses.kt",
+                    """
+                    package com.example.service
+                    import io.github.doljae.kotlinlogging.extensions.AutoLog
+
+                    @AutoLog
+                    class OrderService
+                    @AutoLog
+                    class PaymentService
+                    """.trimIndent(),
+                ),
+                SourceFile.kotlin(
+                    "UserService.kt",
+                    """
+                    package com.example.service
+                    import io.github.doljae.kotlinlogging.extensions.AutoLog
+
+                    @AutoLog
+                    class UserService
+                    """.trimIndent(),
+                ),
+                SourceFile.kotlin(
+                    "OrderRepository.kt",
+                    """
+                    package com.example.repository
+                    import io.github.doljae.kotlinlogging.extensions.AutoLog
+
+                    @AutoLog
+                    class OrderRepository
+                    """.trimIndent(),
+                ),
+            )
+
+        val compilation =
+            KotlinCompilation().apply {
+                this.sources = sources
+                configureKsp {
+                    symbolProcessorProviders += LoggerProcessorProvider()
+                }
+                inheritClassPath = true
+            }
+
+        compilation.compile()
+
+        // Four classes across three source files, but only two packages.
+        val generatedFiles = compilation.generatedExtensionsFiles()
+        generatedFiles.map { it.name } shouldBe
+            listOf("KotlinLoggingExtensions.kt", "KotlinLoggingExtensions.kt")
+
+        val serviceFile = compilation.generatedExtensionsFileContaining("OrderService")
+        val serviceContent = serviceFile?.readText() ?: ""
+
+        // All three service classes share one file, sorted by qualified name.
+        serviceContent shouldContain "val OrderService.log: KLogger"
+        serviceContent shouldContain "val PaymentService.log: KLogger"
+        serviceContent shouldContain "val UserService.log: KLogger"
+        serviceContent.indexOf("val OrderService.log") shouldBeLessThan
+            serviceContent.indexOf("val PaymentService.log")
+
+        // Imports are emitted once for the whole file, not once per class.
+        serviceContent.split("import io.github.oshai.kotlinlogging.KLogger").size shouldBe 2
+
+        // A different package gets its own file.
+        serviceContent shouldNotContain "val OrderRepository.log"
+        compilation.generatedExtensionsFileContaining("OrderRepository")?.readText() shouldContain
+            "package com.example.repository"
     }
 
     @Test
@@ -853,10 +855,7 @@ class LoggerProcessorTest {
 
         val result = compilation.compile()
 
-        val generatedFile =
-            compilation.kspSourcesDir.walkTopDown().find {
-                it.name == "ShadowedClassKotlinLoggingExtensions.kt"
-            }
+        val generatedFile = compilation.generatedExtensionsFileContaining("ShadowedClass")
 
         // Generation must not be skipped: top-level functions in the file still resolve to the
         // top-level property, so its presence is not a signal to leave the class without a logger.


### PR DESCRIPTION
Closes #137

> **Stacked on #146.** Base branch is `feat/warn-top-level-log-shadowing`, not `main` — #146 adds the shadowing warning inside the generation path that this PR then refactors, so keeping them independent would guarantee a conflict. Review/merge #146 first; this PR's base retargets to `main` automatically once it lands.

Extensions are now grouped by package and written to one `KotlinLoggingExtensions.kt` per package.

## Measured impact

Taken on `workload` by making a real content change to a single source file and counting rewritten outputs:

| | `main` (per class, isolating) | this PR (per package, aggregating) |
|---|---|---|
| Generated files, clean build | **17** | **3** |
| Files rewritten after editing one source file | **1** | **3** (all) |

Incremental builds genuinely get more expensive, and that is inherent: a package file aggregates contributions from several source files, so `Dependencies(aggregating = true)` is required. An isolating dependency would leave unchanged contributing files unprocessed and their extensions would silently vanish from the regenerated file.

What bounds the regression is that work per edit is now proportional to **package count, not class count**. On a codebase with 2,000 classes across 100 packages that is 100 files per edit instead of 1, against a clean-build saving of 2,000 → 100.

Wall-clock time was deliberately not measured — `workload` is too small for timing to be anything but noise, so no figure is claimed.

## Why one file per package, not one per project

The extension must live in the target class's own package for `log` to resolve without an import, and a Kotlin file declares exactly one package. One file per package is the floor reachable without forcing users to add imports.

## Implementation notes

- **Determinism.** Entries are sorted by qualified name; verified byte-identical across two `clean` + `kspKotlin` cycles.
- **Round handling.** `process()` may run over several rounds and `createNewFile` cannot write the same path twice. A package written again in a later round gets a numbered file rather than losing its extensions.
- **Default package bug fix.** The old code emitted a bare `package ` line for classes in the default package, which is not valid Kotlin. The declaration is now omitted when the package name is empty. Happy to split this out if you would rather it landed separately.
- **Test strategy.** Generated code was located by a per-class file name, which no longer identifies a class. Tests now locate it by the declaration it must contain — asserting the same thing the file name did.

## Verification

`./gradlew clean build` (includes ktlint) passes. All 34 existing tests kept, including inner classes, generics, enums, `internal` visibility and the reserved-keyword package (`examples.reserved.is`), plus a new test asserting one file per package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)