### PR TITLE
feat!: make project-wide generation the default

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,14 @@
 **Elegant [kotlin-logging](https://github.com/oshai/kotlin-logging) extensions for zero-boilerplate logger generation in
 Kotlin classes using [KSP](https://github.com/google/ksp)**
 
-**Write `log.info { }` in annotated classes without boilerplate!**
+**Write `log.info { }` in any class without boilerplate!**
 
 ## 🚀 Quick Start
 
 ### What It Does
 
-Generates logger extensions at compile time for classes annotated with `@AutoLog`.
-No manual logger declarations needed in opted-in classes.
-(`@GenerateLogger` is still supported for backward compatibility, but deprecated.)
+Generates a `log` extension at compile time for every class in your project. No annotations, no
+configuration — add the processor and `log` is there.
 
 ```kotlin
 // ❌ Before: Manual logger in every class
@@ -31,7 +30,6 @@ class UserService {
 }
 
 // ✅ After: Just use log directly
-@AutoLog
 class UserService {
     fun createUser() {
         log.info { "Creating user" }  // Auto-generated!
@@ -56,27 +54,17 @@ repositories {
 }
 
 dependencies {
-    compileOnly("io.github.doljae:kotlin-logging-extensions:2.4.0") // for @AutoLog
     ksp("io.github.doljae:kotlin-logging-extensions:2.4.0")
     implementation("io.github.oshai:kotlin-logging-jvm:8.0.4")
     implementation("ch.qos.logback:logback-classic:1.6.0") // Logger implementation required
 }
-
-// Optional: enable PackageScan mode (see below for details)
-// ksp {
-//     arg("kotlinloggingextensions.mode", "PackageScan")
-//     arg("kotlinloggingextensions.targets", "com.example.*,com.sample.*")
-// }
 ```
 
-**Step 2: Choose your mode — annotation or package scan**
+**Step 2: Use `log`**
 
-**Option A: Annotate individual classes with `@AutoLog`** (annotation-only mode, default)
+Nothing to annotate, nothing to configure:
 
 ```kotlin
-import io.github.doljae.kotlinlogging.extensions.AutoLog
-
-@AutoLog
 class OrderProcessor {
     fun processOrder(id: String) {
         log.info { "Processing order: $id" }
@@ -91,36 +79,6 @@ class OrderProcessor {
 }
 ```
 
-**Option B: Generate loggers for entire packages — no annotation needed** (PackageScan mode)
-
-Configure target packages in `build.gradle.kts`:
-
-```kotlin
-ksp {
-    arg("kotlinloggingextensions.mode", "PackageScan")
-    arg("kotlinloggingextensions.targets", "com.example.service.*,com.example.repository.*")
-}
-```
-
-Every class in the configured packages gets a `log` property automatically:
-
-```kotlin
-// No @AutoLog needed — just use log directly in any class within the target package
-class PaymentService {
-    fun processPayment(id: String) {
-        log.info { "Processing payment: $id" }
-    }
-}
-
-class OrderRepository {
-    fun findById(id: String) {
-        log.debug { "Querying order: $id" }
-    }
-}
-```
-
-Both modes can be combined — a class gets a logger if **either** condition matches (annotation or package match).
-
 **Step 3: Generate Logger Code**
 
 After writing your code, run KSP to generate the logger extensions:
@@ -133,20 +91,60 @@ This will generate the `log` property and resolve any compilation errors in your
 
 That's it! The logger is generated using the fully qualified class name as the logger name.
 
-### Package Scan Mode — Target Rules
+### Scoping Generation
+
+By default every class gets a `log` extension. If you want to narrow that, set a mode in
+`build.gradle.kts`.
+
+**Limit to specific packages** — `PackageScan`:
+
+```kotlin
+ksp {
+    arg("kotlinloggingextensions.mode", "PackageScan")
+    arg("kotlinloggingextensions.targets", "com.example.service.*,com.example.repository.*")
+}
+```
+
+Target rules:
 
 - `com.example` — exact package match only
 - `com.example.*` — matches `com.example` and all sub-packages
 - Multiple targets: comma-separated (e.g., `com.example.*,com.other.*`)
-- Invalid target entries are silently ignored
-- Supported mode values: `AnnotationOnly` (default), `PackageScan` (case/`_`/`-` insensitive)
+- Invalid target entries are ignored with a warning
 - If `kotlinloggingextensions.targets` is set without `mode`, package scanning is enabled automatically when at least one valid target exists
+
+**Limit to explicitly marked classes** — `AnnotationOnly`:
+
+```kotlin
+ksp {
+    arg("kotlinloggingextensions.mode", "AnnotationOnly")
+}
+```
+
+```kotlin
+dependencies {
+    compileOnly("io.github.doljae:kotlin-logging-extensions:2.4.0") // for @AutoLog
+}
+```
+
+```kotlin
+import io.github.doljae.kotlinlogging.extensions.AutoLog
+
+@AutoLog
+class OrderProcessor {
+    fun processOrder(id: String) {
+        log.info { "Processing order: $id" }
+    }
+}
+```
+
+`@AutoLog` also works in `PackageScan` mode, where a class gets a logger if **either** condition
+matches. Mode values are case/`_`/`-` insensitive: `All` (default), `PackageScan`, `AnnotationOnly`.
 
 ## ✨ Features
 
-- **🔧 Zero Boilerplate**: No logger declarations needed - just use `log.info { }`
-- **✅ Explicit Opt-In**: Generate `log` only for classes annotated with `@AutoLog`
-- **📂 Package Scan Mode**: Generate loggers for entire packages without any annotation — configure `mode=PackageScan` and `targets` in `build.gradle.kts`
+- **🔧 Zero Boilerplate**: No logger declarations, no annotations, no configuration — just use `log.info { }`
+- **🎚️ Scope It When You Want To**: Narrow generation to specific packages (`PackageScan`) or to explicitly marked classes (`AnnotationOnly`)
 - **⚡ Compile-time Generation**: Uses KSP for compile-time safety with zero runtime overhead
 - **📦 Package-aware Naming**: Logger names automatically match fully qualified class names
 - **🏗️ kotlin-logging Integration**: Works seamlessly with the standard kotlin-logging library

--- a/processor/src/main/kotlin/io/github/doljae/kotlinlogging/extensions/LoggerGenerationMode.kt
+++ b/processor/src/main/kotlin/io/github/doljae/kotlinlogging/extensions/LoggerGenerationMode.kt
@@ -1,7 +1,13 @@
 package io.github.doljae.kotlinlogging.extensions
 
 enum class LoggerGenerationMode {
+    /** Every class gets a `log` extension. The default when nothing is configured. */
+    ALL,
+
+    /** Only classes annotated with `@AutoLog`. */
     ANNOTATION_ONLY,
+
+    /** Only classes in the configured package targets, plus any annotated with `@AutoLog`. */
     PACKAGE_SCAN,
     ;
 
@@ -15,14 +21,11 @@ enum class LoggerGenerationMode {
                     ?.lowercase()
 
             return when (normalizedValue) {
+                "all", "projectwide" -> ALL
                 "annotation", "annotationonly" -> ANNOTATION_ONLY
                 "packagescan" -> PACKAGE_SCAN
                 else -> null
             }
-        }
-
-        fun fromOption(optionValue: String?): LoggerGenerationMode {
-            return fromOptionOrNull(optionValue) ?: ANNOTATION_ONLY
         }
     }
 }

--- a/processor/src/main/kotlin/io/github/doljae/kotlinlogging/extensions/LoggerProcessor.kt
+++ b/processor/src/main/kotlin/io/github/doljae/kotlinlogging/extensions/LoggerProcessor.kt
@@ -18,7 +18,7 @@ import io.github.doljae.common.StringUtility.wrapReservedWords
 class LoggerProcessor(
     private val codeGenerator: CodeGenerator,
     private val logger: KSPLogger,
-    private val generationMode: LoggerGenerationMode = LoggerGenerationMode.ANNOTATION_ONLY,
+    private val generationMode: LoggerGenerationMode = LoggerGenerationMode.ALL,
     private val packageScanTargetPatterns: Set<String> = emptySet(),
 ) : SymbolProcessor {
     /**
@@ -74,6 +74,10 @@ class LoggerProcessor(
     }
 
     private fun KSClassDeclaration.shouldAutoLog(): Boolean {
+        if (generationMode == LoggerGenerationMode.ALL) {
+            return true
+        }
+
         if (hasLoggerGenerationAnnotation()) {
             return true
         }

--- a/processor/src/main/kotlin/io/github/doljae/kotlinlogging/extensions/LoggerProcessorProvider.kt
+++ b/processor/src/main/kotlin/io/github/doljae/kotlinlogging/extensions/LoggerProcessorProvider.kt
@@ -38,7 +38,7 @@ class LoggerProcessorProvider : SymbolProcessorProvider {
         if (configuredMode != null && parsedConfiguredMode == null) {
             logger.warn(
                 "Unsupported value '$configuredMode' for ${LoggerProcessor.GENERATION_MODE_OPTION_KEY}. " +
-                    "Supported values: AnnotationOnly, PackageScan. Falling back to AnnotationOnly.",
+                    "Supported values: All, AnnotationOnly, PackageScan. Falling back to All.",
             )
         }
 
@@ -54,7 +54,8 @@ class LoggerProcessorProvider : SymbolProcessorProvider {
                 LoggerGenerationMode.PACKAGE_SCAN
             }
             parsedConfiguredMode != null -> parsedConfiguredMode
-            else -> LoggerGenerationMode.ANNOTATION_ONLY
+            // Nothing configured: generate for every class, so that adding the plugin is enough.
+            else -> LoggerGenerationMode.ALL
         }
     }
 

--- a/processor/src/test/kotlin/io/github/doljae/kotlinlogging/extensions/LoggerProcessorTest.kt
+++ b/processor/src/test/kotlin/io/github/doljae/kotlinlogging/extensions/LoggerProcessorTest.kt
@@ -199,7 +199,7 @@ class LoggerProcessorTest {
     }
 
     @Test
-    fun `should not generate log extension for class without AutoLog annotation`() {
+    fun `should not generate log extension for unannotated class in annotation only mode`() {
         val source =
             SourceFile.kotlin(
                 "NoAnnotationClass.kt",
@@ -216,6 +216,10 @@ class LoggerProcessorTest {
                 configureKsp {
                     symbolProcessorProviders += LoggerProcessorProvider()
                 }
+                kspProcessorOptions =
+                    mutableMapOf(
+                        LoggerProcessor.GENERATION_MODE_OPTION_KEY to "AnnotationOnly",
+                    )
                 inheritClassPath = true
             }
 
@@ -471,7 +475,7 @@ class LoggerProcessorTest {
     }
 
     @Test
-    fun `should warn and fall back to annotation only for unsupported mode option`() {
+    fun `should warn and fall back to all for unsupported mode option`() {
         val source =
             SourceFile.kotlin(
                 "UnsupportedModeClass.kt",
@@ -499,9 +503,10 @@ class LoggerProcessorTest {
 
         val generatedFile = compilation.generatedExtensionsFileContaining("UnsupportedModeClass")
 
-        generatedFile shouldBe null
+        // Falling back to the default mode means the class still gets an extension.
+        generatedFile?.exists() shouldBe true
         result.messages shouldContain "Unsupported value 'NotSupported'"
-        result.messages shouldContain "Falling back to AnnotationOnly"
+        result.messages shouldContain "Falling back to All"
     }
 
     @Test
@@ -752,6 +757,75 @@ class LoggerProcessorTest {
         val generatedFile = compilation.generatedExtensionsFileContaining("LegacyAnnotationClass")
 
         generatedFile?.exists() shouldBe true
+    }
+
+    @Test
+    fun `should generate for every class when nothing is configured`() {
+        val source =
+            SourceFile.kotlin(
+                "UnconfiguredClasses.kt",
+                """
+                package com.example.unconfigured
+
+                class PlainClass
+                internal class InternalClass
+                data class DataClass(val id: String)
+                """.trimIndent(),
+            )
+
+        val compilation =
+            KotlinCompilation().apply {
+                sources = listOf(source)
+                configureKsp {
+                    symbolProcessorProviders += LoggerProcessorProvider()
+                }
+                inheritClassPath = true
+            }
+
+        val result = compilation.compile()
+
+        // No @AutoLog, no mode, no targets — adding the processor is enough.
+        compilation.generatedExtensionsFileContaining("PlainClass")?.exists() shouldBe true
+        compilation.generatedExtensionsFileContaining("DataClass")?.exists() shouldBe true
+        compilation.generatedExtensionsFileContaining("InternalClass")?.readText() shouldContain
+            "internal val InternalClass.log: KLogger"
+
+        result.messages shouldNotContain "Unsupported value"
+    }
+
+    @Test
+    fun `should still honour AutoLog when annotation only mode is configured`() {
+        val source =
+            SourceFile.kotlin(
+                "MixedClasses.kt",
+                """
+                package com.example.mixed
+                import io.github.doljae.kotlinlogging.extensions.AutoLog
+
+                @AutoLog
+                class OptedInClass
+                class PlainClass
+                """.trimIndent(),
+            )
+
+        val compilation =
+            KotlinCompilation().apply {
+                sources = listOf(source)
+                configureKsp {
+                    symbolProcessorProviders += LoggerProcessorProvider()
+                }
+                kspProcessorOptions =
+                    mutableMapOf(
+                        LoggerProcessor.GENERATION_MODE_OPTION_KEY to "AnnotationOnly",
+                    )
+                inheritClassPath = true
+            }
+
+        compilation.compile()
+
+        // The one-line escape hatch out of the new default.
+        compilation.generatedExtensionsFileContaining("OptedInClass")?.exists() shouldBe true
+        compilation.generatedExtensionsFileContaining("PlainClass") shouldBe null
     }
 
     @Test


### PR DESCRIPTION
Closes #143

> **Stacked on #147** (which is stacked on #146). Base branch is `feat/one-file-per-package`. Merge order: #146 → #147 → this. Bases retarget automatically as each lands.

**BREAKING CHANGE:** with no configuration, every class now gets a `log` extension. Previously nothing was generated until a class was annotated with `@AutoLog`. Set `kotlinloggingextensions.mode=AnnotationOnly` to keep the old behaviour.

## Why

A KSP plugin that does nothing until configured fails at first run — add the plugin, build, get nothing, go read the docs — and that friction lands exactly when a user is deciding whether to keep the library. Requiring `@AutoLog` on every class also trades one per-class line (`private val log = KotlinLogging.logger {}`) for another, which undercuts the zero-boilerplate premise the library exists for.

This restores the behaviour of v2.3.0 and earlier. That behaviour was changed in `5bc443d`, a commit whose stated purpose was adding package-scan targets; the default flip appeared neither in its title nor as a `BREAKING CHANGE` footer, and shipped in the **v2.3.1 patch release**. See #143 for the full history and the counterarguments that were weighed.

## Changes

- Add `LoggerGenerationMode.ALL`, accepted as `All` / `ProjectWide`, and make it the fallback when neither a mode nor targets are configured
- Explicit modes and configured targets keep taking precedence — only the "nothing configured" branch changes
- Remove `LoggerGenerationMode.fromOption`, which nothing called and which would have silently carried the old default
- Rework the README around a single path (install → build → use `log`) with a **Scoping Generation** section for `PackageScan` and `AnnotationOnly`, replacing the "Step 2: Choose your mode" fork

`@AutoLog` stays. It remains the switch for `AnnotationOnly` users, still works additively in `PackageScan` mode, and existing annotated code stays valid.

## Why this is not compile-breaking

Restoring project-wide generation only **adds** extension properties; it removes none. Classes that declare their own `log`, or whose companion does, are still skipped by `hasDeclaredLogProperty()`.

The one real interaction is a top-level `log` being shadowed inside classes that never opted in — which is exactly why #146 (the shadowing warning) is beneath this in the stack, and #147 (one file per package) bounds the generation cost that project-wide output implies.

## Verification

`./gradlew clean build` (includes ktlint) passes. Two tests added — every class generated with no configuration at all (plain, `internal`, and `data` classes), and `AnnotationOnly` still honouring `@AutoLog` while skipping unannotated classes. Two existing tests were updated deliberately because their semantics change: unannotated-class non-generation now needs `mode=AnnotationOnly` stated, and the unsupported-mode fallback is now `All`.

In `workload`, the `examples` package goes from 15 generated extensions to 24 — the previously unannotated classes now covered.

## Open item from #143

The recommendation carried a caveat that still stands: the argument leans on the inference that few users are on `@AutoLog` today, evidenced only by the absence of any report about v2.3.1 silently removing loggers. If Maven Central adoption figures since v2.3.1 say otherwise, the better answer is to keep `AnnotationOnly` and ship only the README rework from this PR. Worth checking before release.

Release notes should state the change explicitly, including that v2.3.1 changed this default silently in a patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)