### PR TITLE
chore: ignore .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -321,3 +321,6 @@ gradle-local.properties
 # Build reports
 .build-report/
 
+# macOS
+.DS_Store
+


### PR DESCRIPTION
macOS Finder drops `.DS_Store` into any directory it browses, so it shows up as untracked noise on every `git status` for macOS contributors. The toptal-generated template this file came from covers Gradle/Kotlin/JetBrains but not macOS.

## Changes

- Add `.DS_Store` to `.gitignore`

## Notes

No `.DS_Store` is currently tracked in the repo, so nothing needs `git rm --cached`.

## Verification

`git check-ignore -v .DS_Store` resolves to the new rule, and `git status` is clean with the file present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)