### PR TITLE
fix(processor): separate generated file names per source set

### DIFF
--- a/processor/src/main/kotlin/io/github/doljae/kotlinlogging/extensions/LoggerProcessor.kt
+++ b/processor/src/main/kotlin/io/github/doljae/kotlinlogging/extensions/LoggerProcessor.kt
@@ -1,5 +1,6 @@
 package io.github.doljae.kotlinlogging.extensions
 
+import com.google.devtools.ksp.KspExperimental
 import com.google.devtools.ksp.getVisibility
 import com.google.devtools.ksp.processing.CodeGenerator
 import com.google.devtools.ksp.processing.Dependencies
@@ -30,7 +31,16 @@ class LoggerProcessor(
      */
     private val writtenFilesPerPackage = mutableMapOf<String, Int>()
 
+    /**
+     * Distinguishes this compilation's generated file from the one another source set produces for
+     * the same package. Set on every [process] call, before any file is written.
+     */
+    private var moduleDiscriminator: String = ""
+
+    @OptIn(KspExperimental::class)
     override fun process(resolver: Resolver): List<KSAnnotated> {
+        moduleDiscriminator = discriminatorFor(resolver.getModuleName().asString())
+
         val classes =
             resolver
                 .getNewFiles()
@@ -203,8 +213,8 @@ class LoggerProcessor(
             }.trimEnd()
 
         val writeCount = writtenFilesPerPackage.merge(packageName, 1, Int::plus)!!
-        val fileName =
-            if (writeCount == 1) GENERATED_FILE_NAME else "$GENERATED_FILE_NAME$writeCount"
+        val baseName = "$GENERATED_FILE_NAME$moduleDiscriminator"
+        val fileName = if (writeCount == 1) baseName else "$baseName$writeCount"
 
         codeGenerator
             .createNewFile(
@@ -299,8 +309,28 @@ class LoggerProcessor(
         public const val LEGACY_PACKAGE_PREFIXES_OPTION_KEY: String =
             "kotlinloggingextensions.autoGeneratePackagePrefixes"
 
-        /** Base name of the per-package generated file. */
+        /** Base name of the per-package generated file, before the module discriminator. */
         public const val GENERATED_FILE_NAME: String = "KotlinLoggingExtensions"
+
+        /**
+         * Turns a KSP module name into a file-name suffix that separates this compilation's output
+         * from every other source set's.
+         *
+         * A file holding top-level declarations compiles to a JVM class named after the file, so two
+         * source sets that share a package and a file name produce the same class twice. The test
+         * compilation's copy then shadows the main one on the runtime classpath and every `log` in
+         * main throws `NoSuchMethodError` — at runtime only, because compilation sees main's classes
+         * on the classpath and resolves fine.
+         *
+         * The module name is the only thing KSP exposes that differs between source sets: Gradle
+         * reports `group:project` for main and `group:project_test` for the test compilation. Only the
+         * part after the last `:` is used, and anything not legal in an identifier is replaced.
+         */
+        internal fun discriminatorFor(moduleName: String): String {
+            val withoutGroup = moduleName.substringAfterLast(':')
+            val sanitized = withoutGroup.map { character -> if (character.isLetterOrDigit()) character else '_' }.joinToString("")
+            return if (sanitized.isEmpty()) "" else "_$sanitized"
+        }
         private const val LOGGER_GENERATION_ANNOTATION = "io.github.doljae.kotlinlogging.extensions.AutoLog"
 
         // Ref: https://kotlinlang.org/docs/keyword-reference.html

--- a/processor/src/test/kotlin/io/github/doljae/kotlinlogging/extensions/LoggerProcessorTest.kt
+++ b/processor/src/test/kotlin/io/github/doljae/kotlinlogging/extensions/LoggerProcessorTest.kt
@@ -13,6 +13,7 @@ import io.kotest.matchers.ints.shouldBeLessThan
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotContain
+import io.kotest.matchers.string.shouldStartWith
 import org.jetbrains.kotlin.compiler.plugin.ExperimentalCompilerApi
 import org.junit.jupiter.api.Test
 
@@ -872,9 +873,12 @@ class LoggerProcessorTest {
         result.exitCode shouldBe KotlinCompilation.ExitCode.OK
 
         // Four classes across three source files, but only two packages.
+        // The name carries a module discriminator, so match the base rather than the whole name.
         val generatedFiles = compilation.generatedExtensionsFiles()
-        generatedFiles.map { it.name } shouldBe
-            listOf("KotlinLoggingExtensions.kt", "KotlinLoggingExtensions.kt")
+        generatedFiles.size shouldBe 2
+        generatedFiles.forEach { file ->
+            file.name shouldStartWith LoggerProcessor.GENERATED_FILE_NAME
+        }
 
         val serviceFile = compilation.generatedExtensionsFileContaining("OrderService")
         val serviceContent = serviceFile?.readText() ?: ""
@@ -1004,9 +1008,24 @@ class LoggerProcessorTest {
         val result = compilation.compile()
 
         result.exitCode shouldBe KotlinCompilation.ExitCode.OK
-        compilation.generatedExtensionsFileContaining("FirstRoundClass")?.name shouldBe
-            "KotlinLoggingExtensions.kt"
-        compilation.generatedExtensionsFileContaining("LateClass")?.name shouldBe
-            "KotlinLoggingExtensions2.kt"
+
+        // The later round is numbered on top of the discriminated base name, not instead of it.
+        val firstRoundName = compilation.generatedExtensionsFileContaining("FirstRoundClass")?.name
+        val lateRoundName = compilation.generatedExtensionsFileContaining("LateClass")?.name
+
+        firstRoundName shouldStartWith LoggerProcessor.GENERATED_FILE_NAME
+        lateRoundName shouldBe firstRoundName?.removeSuffix(".kt") + "2.kt"
+    }
+
+    @Test
+    fun `should derive a file name discriminator that separates source sets`() {
+        // Gradle reports 'group:project' for main and 'group:project_test' for the test compilation,
+        // which is the only signal KSP exposes that tells the two compilations apart.
+        LoggerProcessor.discriminatorFor("io.github.doljae:workload") shouldBe "_workload"
+        LoggerProcessor.discriminatorFor("io.github.doljae:workload_test") shouldBe "_workload_test"
+
+        // Anything not legal in an identifier has to go, or the generated file will not compile.
+        LoggerProcessor.discriminatorFor("my-app.jvm") shouldBe "_my_app_jvm"
+        LoggerProcessor.discriminatorFor("") shouldBe ""
     }
 }

--- a/workload/build.gradle.kts
+++ b/workload/build.gradle.kts
@@ -27,6 +27,8 @@ dependencies {
 
     // kotlin-logging-extensions (using project dependency for development)
     ksp(project(":processor"))
+    kspTest(project(":processor"))
+    kspTest(project(":processor"))
 }
 
 tasks.test {

--- a/workload/build.gradle.kts
+++ b/workload/build.gradle.kts
@@ -28,7 +28,6 @@ dependencies {
     // kotlin-logging-extensions (using project dependency for development)
     ksp(project(":processor"))
     kspTest(project(":processor"))
-    kspTest(project(":processor"))
 }
 
 tasks.test {

--- a/workload/src/test/kotlin/examples/ComplexStructuresTest.kt
+++ b/workload/src/test/kotlin/examples/ComplexStructuresTest.kt
@@ -107,4 +107,13 @@ class ComplexStructuresTest {
         // No extension exists for it — the point is that its file still compiles.
         usePrivateWorker() shouldBe "no generated log here"
     }
+
+    @Test
+    fun `Test source classes get their own logger without shadowing main`() {
+        // Both source sets generate a file for package `examples`. If they shared a file name they
+        // would compile to the same JVM class, and the test copy would shadow main's at runtime —
+        // every assertion above would fail with NoSuchMethodError while still compiling cleanly.
+        log.name shouldBe "examples.ComplexStructuresTest"
+        SingletonService.log.name shouldBe "examples.SingletonService"
+    }
 }


### PR DESCRIPTION
## Problem

`#147` made the processor emit one file per package under a fixed name, `KotlinLoggingExtensions.kt`. A Kotlin file of top-level declarations compiles to a JVM class named after the file, so **every source set that contains the same package produced the same class**: `<pkg>.KotlinLoggingExtensionsKt`.

Under KSP2 that only bites when a project runs `kspTest` as well as `ksp` — which is exactly what KSP2 requires, since `ksp(...)` no longer feeds the test source set the way KSP1 did. When both run:

- test output comes **before** main output on the runtime classpath
- the test copy of `<pkg>.KotlinLoggingExtensionsKt` shadows main's
- it only contains getters for classes declared in the test source set

So every `log` access on a main-source class throws `NoSuchMethodError` **at runtime**, while everything compiles cleanly — compilation resolves against main's own output directory, not the merged runtime classpath. This is the worst shape of bug: invisible to the compiler, invisible to a test suite that doesn't touch both source sets, and a hard failure in production.

Reproduced in-repo by adding `kspTest(project(":processor"))` to `workload`: 11 tests failed with `NoSuchMethodError`.

## Fix

Suffix the generated file name with a discriminator derived from the module name:

```
main/kotlin/examples/KotlinLoggingExtensions_workload.kt
test/kotlin/examples/KotlinLoggingExtensions_workload_test.kt
```

`Resolver.getModuleName()` is the only source-set discriminator KSP exposes. Probed live, it returns `io.github.doljae:workload` for main and `io.github.doljae:workload_test` for test — the group prefix is dropped and non-alphanumerics are mapped to `_` so the result is always a legal file/class name.

### Trade-offs and things to verify

- **`getModuleName()` is `@KspExperimental`.** It exists in KSP 2.1.21-2.0.2 and 2.3.11 (verified). If we ever target the KSP 1.x line, this needs re-checking. There is no stable alternative — KSP does not otherwise tell a processor which source set it is running for.
- **Generated file names are not API**, but anyone who has wired tooling to the literal name `KotlinLoggingExtensions.kt` will see it change. `LoggerProcessor.GENERATED_FILE_NAME` remains the base name.
- **Alternative considered:** put generated extensions in a synthetic package instead of the target's own package. Rejected — the whole point of generating into the target's package is that `log` resolves with no import.
- The multi-round numbering suffix (`...2.kt`) still applies on top of the discriminator.

## Regression guard

`kspTest(project(":processor"))` stays in `workload/build.gradle.kts` deliberately — it is what makes the two source sets collide. `ComplexStructuresTest` now asserts that a test-source class and a main-source class both resolve their own logger, which fails with `NoSuchMethodError` if the names ever converge again.

`discriminatorFor` also has a direct unit test for the sanitizing rules.

`./gradlew clean build`: 59 tests, 0 failures (was 57).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
