### PR TITLE
fix(ci): release on doc-only release commits, document kspTest

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -7,11 +7,10 @@ on:
       - 2.1.x
       - 2.2.x
       - 2.3.x
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-      - '.github/ISSUE_TEMPLATE/**'
-      - '.github/workflows/**'
+    # No paths-ignore: a release PR that only rewrites version references in
+    # README and the issue templates touches nothing else, and every such path
+    # was ignored here — so v3.0.0 landed on main and never released. The
+    # commit-message check below is the real gate; it costs ~10s on other pushes.
   workflow_dispatch:
     inputs:
       force:

--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ dependencies {
 }
 ```
 
+Each source set is processed separately, so add `kspTest(...)` as well if your test classes use `log`:
+
+```kotlin
+dependencies {
+    kspTest("io.github.doljae:kotlin-logging-extensions:3.0.0")
+}
+```
+
 **Step 2: Use `log`**
 
 Nothing to annotate, nothing to configure:

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ its class ([#152](https://github.com/doljae/kotlin-logging-extensions/issues/152
 | `2.1.21` | `2.1.21-2.0.2` | 8.11.1 |
 | `2.2.21` | `2.2.21-2.0.4` | 8.14.3 |
 | `2.3.21` | `2.3.10` | 9.0.0 |
-| `2.4.10` | `2.3.11` | 9.6.1 |
+| `2.4.10` | `2.3.11` | 9.7.0 |
 
 Kotlin `2.0` is the floor because that is the metadata version the annotations artifact is compiled
 against, not because anything below it was found to break.


### PR DESCRIPTION
## Why

`Release v3.0.0 (#158)` merged to main on 2026-08-11 and **no release happened** — no `v3.0.0` tag, no GitHub Release, nothing on Maven Central (both coordinates 404).

Root cause: the release PR only had version references left to rewrite, because `gradle.properties` had already gone to `3.0.0` in #155. The files it touched were:

- `README.md`
- `.github/ISSUE_TEMPLATE/bug_report.yml`
- `.github/ISSUE_TEMPLATE/question.yml`
- `.github/ISSUE_TEMPLATE/version_compatibility.yml`

All four match `auto-release.yml`'s `paths-ignore`, so the workflow never triggered. `gh run list --workflow=auto-release.yml` has no run for that push.

## What

- Remove `paths-ignore` from `auto-release.yml`. The commit-message regex is the real gate and no-ops in ~10s on non-release pushes, so the filter saved nothing while being able to swallow a release whenever the version bump landed ahead of the release PR.
- Document `kspTest(...)` in the Quick Start. KSP processes each source set separately, so test classes get no `log` unless the processor is on `kspTest` too — found while building real consumer projects against the 3.0.0 artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)