### PR TITLE
docs: bring docs and issue templates in line with 3.0.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -8,7 +8,8 @@ body:
       value: |
         Thank you for taking the time to report a bug! Please fill out this form to help us understand and reproduce the issue.
 
-        **⚠️ Important**: This library is highly dependent on Kotlin and KSP versions. Please ensure you're using the correct versions before reporting.
+        **⚠️ Important**: From `3.0.0` the library supports a range of Kotlin versions (JDK 17+, Kotlin 2.0+, KSP matching your Kotlin version). Please check the
+        [compatibility table](https://github.com/doljae/kotlin-logging-extensions#-version-compatibility) before reporting.
 
   - type: checkboxes
     id: prerequisites
@@ -18,7 +19,7 @@ body:
       options:
         - label: I have searched existing issues to make sure this is not a duplicate
           required: true
-        - label: I am using the exact Kotlin and KSP versions specified in the documentation
+        - label: I am on JDK 17+, Kotlin 2.0+, and a KSP version matching my Kotlin version
           required: true
         - label: I have tried building with a clean Gradle build (`./gradlew clean build`)
           required: true
@@ -113,8 +114,11 @@ body:
 
         dependencies {
             ksp("io.github.doljae:kotlin-logging-extensions:3.0.0")
-            implementation("io.github.doljae:kotlin-logging-extensions:3.0.0")
-            implementation("io.github.oshai:kotlin-logging-jvm:7.0.7")
+            kspTest("io.github.doljae:kotlin-logging-extensions:3.0.0") // if test classes use `log`
+            implementation("io.github.oshai:kotlin-logging-jvm:8.0.4")
+
+            // Only for AnnotationOnly / PackageScan modes, where you write @Log yourself.
+            compileOnly("io.github.doljae:kotlin-logging-extensions-annotations:3.0.0")
         }
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -8,7 +8,9 @@ body:
       value: |
         Thank you for suggesting a new feature! Please provide as much detail as possible to help us understand your request.
         
-        **⚠️ Version Compatibility**: This library is highly dependent on Kotlin and KSP versions. Please ensure you're using the correct versions before requesting features.
+        **⚠️ Version Compatibility**: Please check the
+        [compatibility table](https://github.com/doljae/kotlin-logging-extensions#-version-compatibility)
+        first — the feature you want may already exist on a newer version.
 
   - type: checkboxes
     id: prerequisites

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -10,7 +10,7 @@ body:
         
         **⚠️ Version Compatibility**: Please check the
         [compatibility table](https://github.com/doljae/kotlin-logging-extensions#-version-compatibility)
-        first — the feature you want may already exist on a newer version.
+        first: the feature you want may already exist on a newer version.
 
   - type: checkboxes
     id: prerequisites

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -10,7 +10,7 @@ body:
         
         **Before asking**: Please check the [documentation](https://github.com/doljae/kotlin-logging-extensions/blob/main/README.md) and [existing issues](https://github.com/doljae/kotlin-logging-extensions/issues) first.
         
-        **⚠️ Version Compatibility**: If you're experiencing issues, check that you're on JDK 17+, Kotlin 2.0+, and a KSP version matching your Kotlin version — see the
+        **⚠️ Version Compatibility**: If you're experiencing issues, check that you're on JDK 17+, Kotlin 2.0+, and a KSP version matching your Kotlin version. See the
         [compatibility table](https://github.com/doljae/kotlin-logging-extensions#-version-compatibility).
 
   - type: checkboxes

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -10,7 +10,8 @@ body:
         
         **Before asking**: Please check the [documentation](https://github.com/doljae/kotlin-logging-extensions/blob/main/README.md) and [existing issues](https://github.com/doljae/kotlin-logging-extensions/issues) first.
         
-        **⚠️ Version Compatibility**: This library is highly dependent on Kotlin and KSP versions. If you're experiencing issues, please ensure you're using the exact versions specified in the documentation.
+        **⚠️ Version Compatibility**: If you're experiencing issues, check that you're on JDK 17+, Kotlin 2.0+, and a KSP version matching your Kotlin version — see the
+        [compatibility table](https://github.com/doljae/kotlin-logging-extensions#-version-compatibility).
 
   - type: checkboxes
     id: prerequisites

--- a/.github/ISSUE_TEMPLATE/version_compatibility.yml
+++ b/.github/ISSUE_TEMPLATE/version_compatibility.yml
@@ -9,7 +9,7 @@ body:
         This template is specifically for version compatibility issues between Kotlin, KSP, and kotlin-logging-extensions.
 
         **Requirements from `3.0.0`**: JDK 17+, Kotlin 2.0+, a KSP version matching your Kotlin version, kotlin-logging 5.0.0+.
-        The library version no longer mirrors your Kotlin version — see the
+        The library version no longer mirrors your Kotlin version. See the
         [verified compatibility table](https://github.com/doljae/kotlin-logging-extensions#-version-compatibility).
 
   - type: input

--- a/.github/ISSUE_TEMPLATE/version_compatibility.yml
+++ b/.github/ISSUE_TEMPLATE/version_compatibility.yml
@@ -7,8 +7,10 @@ body:
     attributes:
       value: |
         This template is specifically for version compatibility issues between Kotlin, KSP, and kotlin-logging-extensions.
-        
-        **Required versions**: Kotlin `2.1.21`, KSP `2.1.21-2.0.2`
+
+        **Requirements from `3.0.0`**: JDK 17+, Kotlin 2.0+, a KSP version matching your Kotlin version, kotlin-logging 5.0.0+.
+        The library version no longer mirrors your Kotlin version — see the
+        [verified compatibility table](https://github.com/doljae/kotlin-logging-extensions#-version-compatibility).
 
   - type: input
     id: library-version
@@ -46,6 +48,17 @@ body:
     validations:
       required: true
 
+  # Keep this input last: create-release-pr.yml rewrites `placeholder:` lines in this file by
+  # position (1=library, 2=Kotlin, 3=KSP, 4=kotlin-logging), so any new input must sit after them.
+  - type: input
+    id: jdk-version
+    attributes:
+      label: Your JDK Version
+      description: Which JDK is Gradle running on? (`./gradlew -version`)
+      placeholder: "e.g., 17"
+    validations:
+      required: true
+
   - type: textarea
     id: error-message
     attributes:
@@ -77,8 +90,8 @@ body:
       description: Check all that you've attempted
       options:
         - label: Clean build (`./gradlew clean build`)
-        - label: Upgrading Kotlin to the required version (2.1.21)
-        - label: Upgrading KSP to the required version (2.1.21-2.0.2)
+        - label: Building on JDK 17 or later
+        - label: Matching my KSP version to my Kotlin version
         - label: Clearing Gradle cache
         - label: Invalidating IDE caches and restarting
 

--- a/.github/ISSUE_TEMPLATE/version_compatibility.yml
+++ b/.github/ISSUE_TEMPLATE/version_compatibility.yml
@@ -48,8 +48,9 @@ body:
     validations:
       required: true
 
-  # Keep this input last: create-release-pr.yml rewrites `placeholder:` lines in this file by
-  # position (1=library, 2=Kotlin, 3=KSP, 4=kotlin-logging), so any new input must sit after them.
+  # Keep this input below the four above it. create-release-pr.yml rewrites the quoted e.g.
+  # placeholders in this file by position (1=library, 2=Kotlin, 3=KSP, 4=kotlin-logging), so a new
+  # input inserted among them would be handed a version string it should not have.
   - type: input
     id: jdk-version
     attributes:

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -28,7 +28,7 @@ project-wide by default; `kotlinloggingextensions.mode` narrows it to `PackageSc
 - `build.gradle.kts`: Build configuration. Do not suggest Groovy syntax for Gradle.
 
 ## Dependencies
-- JDK: 17 (`jvmToolchain(17)`; do not raise it — it is published as `org.gradle.jvm.version`)
+- JDK: 17 (`jvmToolchain(17)`; do not raise it, since it is published as `org.gradle.jvm.version`)
 - Kotlin: 2.x
 - KSP: 2.x
 - Kotlin Logging: `io.github.oshai:kotlin-logging-jvm` 5.0.0+

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -3,7 +3,12 @@
 You are an expert Kotlin developer assisting with a KSP (Kotlin Symbol Processing) project.
 
 ## Project Context
-This project automatically generates `log` properties for Kotlin classes using KSP.
+This project automatically generates `log` properties for Kotlin classes using KSP. Generation is
+project-wide by default; `kotlinloggingextensions.mode` narrows it to `PackageScan` or
+`AnnotationOnly`.
+- **Module `annotations`**: `@Log` (and the deprecated `@AutoLog`), published separately as
+  `kotlin-logging-extensions-annotations`. It is the only artifact on a consumer's compile classpath,
+  so it must stay dependency-free and on Kotlin language/API 2.0.
 - **Module `processor`**: Contains the KSP logic.
 - **Module `workload`**: Contains example code and integration scenarios.
 
@@ -17,12 +22,15 @@ This project automatically generates `log` properties for Kotlin classes using K
 
 ## Important Files
 - `LoggerProcessor.kt`: Main logic for code generation.
-- `LoggerProcessorProvider.kt`: Entry point for KSP.
+- `LoggerProcessorProvider.kt`: Entry point for KSP, option parsing and mode resolution.
+- `LoggerGenerationMode.kt`: `All` / `PackageScan` / `AnnotationOnly`.
+- `annotations/.../Log.kt`: The `@Log` annotation (`AutoLog.kt` is the deprecated pre-3.0.0 name).
 - `build.gradle.kts`: Build configuration. Do not suggest Groovy syntax for Gradle.
 
 ## Dependencies
+- JDK: 17 (`jvmToolchain(17)`; do not raise it — it is published as `org.gradle.jvm.version`)
 - Kotlin: 2.x
 - KSP: 2.x
-- Kotlin Logging: `io.github.oshai:kotlin-logging-jvm`
+- Kotlin Logging: `io.github.oshai:kotlin-logging-jvm` 5.0.0+
 
 When suggesting code changes, always prioritize thread safety and build performance.

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -261,7 +261,10 @@ jobs:
         # Update issue templates - use simpler approach for placeholders
         templates = [
             ('bug_report.yml', [
+                # As in the README block above: the first pattern requires the colon immediately
+                # after the artifact id, so it does not match the -annotations coordinate.
                 (r'io\.github\.doljae:kotlin-logging-extensions:[0-9]+\.[0-9]+\.[0-9]+(-[0-9]+\.[0-9]+\.[0-9]+)?', f'io.github.doljae:kotlin-logging-extensions:{VERSION}'),
+                (r'io\.github\.doljae:kotlin-logging-extensions-annotations:[0-9]+\.[0-9]+\.[0-9]+(-[0-9]+\.[0-9]+\.[0-9]+)?', f'io.github.doljae:kotlin-logging-extensions-annotations:{VERSION}'),
                 (r'kotlin\("jvm"\) version "[0-9]+\.[0-9]+\.[0-9]+"', f'kotlin("jvm") version "{KOTLIN_VERSION}"'),
                 (r'id\("com\.google\.devtools\.ksp"\) version "[0-9]+\.[0-9]+\.[0-9]+(-[0-9]+\.[0-9]+\.[0-9]+)?"', f'id("com.google.devtools.ksp") version "{KSP_VERSION}"'),
                 (r'ch\.qos\.logback:logback-classic:[0-9]+\.[0-9]+\.[0-9]+', f'ch.qos.logback:logback-classic:{LOGBACK_VERSION}'),

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ This will generate the `log` property and resolve any compilation errors in your
 That's it! The logger is generated using the fully qualified class name as the logger name.
 
 Output lands in `build/generated/ksp/<source set>/kotlin`, one file per package named
-`KotlinLoggingExtensions_<module>.kt` — the module suffix is what keeps `main` and `test` from
+`KotlinLoggingExtensions_<module>.kt`. The module suffix is what keeps `main` and `test` from
 colliding when they share a package.
 
 ### Scoping Generation

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ repositories {
 dependencies {
     ksp("io.github.doljae:kotlin-logging-extensions:3.0.0")
     implementation("io.github.oshai:kotlin-logging-jvm:8.0.4")
-    implementation("ch.qos.logback:logback-classic:1.6.1") // Logger implementation required
+    implementation("ch.qos.logback:logback-classic:1.6.2") // Logger implementation required
 }
 ```
 
@@ -98,6 +98,10 @@ After writing your code, run KSP to generate the logger extensions:
 This will generate the `log` property and resolve any compilation errors in your IDE.
 
 That's it! The logger is generated using the fully qualified class name as the logger name.
+
+Output lands in `build/generated/ksp/<source set>/kotlin`, one file per package named
+`KotlinLoggingExtensions_<module>.kt` — the module suffix is what keeps `main` and `test` from
+colliding when they share a package.
 
 ### Scoping Generation
 
@@ -285,7 +289,7 @@ repositories {
 dependencies {
     ksp("io.github.doljae:kotlin-logging-extensions:3.0.0")
     implementation("io.github.oshai:kotlin-logging-jvm:8.0.4")
-    implementation("ch.qos.logback:logback-classic:1.6.1")
+    implementation("ch.qos.logback:logback-classic:1.6.2")
 
     // Only needed if you write @Log yourself (AnnotationOnly / PackageScan modes).
     compileOnly("io.github.doljae:kotlin-logging-extensions-annotations:3.0.0")

--- a/docs/project-instructions.md
+++ b/docs/project-instructions.md
@@ -35,7 +35,7 @@ Always use the Gradle wrapper (`./gradlew`), never a system-installed Gradle.
 - Both modules use `jvmToolchain(17)`. The toolchain sets `org.gradle.jvm.version` in the published
   module metadata, so raising it breaks resolution on JDK 17 consumers (issue #152).
 - The processor matches `@Log`/`@AutoLog` by qualified name and must not depend on `:annotations`
-  outside tests. A `typealias` shim is not usable — KSP reports aliases under their own name.
+  outside tests. A `typealias` shim is not usable, because KSP reports aliases under their own name.
 - Generation is project-wide (`All`) by default; `kotlinloggingextensions.mode` /
   `.targets` narrow it. One file per package per source set:
   `KotlinLoggingExtensions_<module>.kt`.

--- a/docs/project-instructions.md
+++ b/docs/project-instructions.md
@@ -6,9 +6,10 @@ KSP plugin that generates `kotlin-logging` `log` extensions at compile time.
 
 | Module | Purpose |
 |--------|---------|
+| `annotations` | `@Log` (and deprecated `@AutoLog`), published as `kotlin-logging-extensions-annotations` |
 | `processor` | KSP processor, code generation, processor unit tests |
 | `workload` | Consumer module for integration verification of generated extensions |
-| `scripts` | Release and maintenance scripts |
+| `scripts` | Release and maintenance scripts (not a Gradle module) |
 
 ## Build Commands
 
@@ -17,6 +18,7 @@ KSP plugin that generates `kotlin-logging` `log` extensions at compile time.
 ./gradlew test              # all tests
 ./gradlew :processor:test   # processor tests only
 ./gradlew :workload:test    # workload tests only
+./gradlew ktlintCheck       # lint
 ```
 
 Always use the Gradle wrapper (`./gradlew`), never a system-installed Gradle.
@@ -27,6 +29,16 @@ Always use the Gradle wrapper (`./gradlew`), never a system-installed Gradle.
 - Keep `workload` focused on usage examples and regression coverage.
 - Generated output must be deterministic for identical source inputs.
 - Do not change generated extension signatures without updating tests.
+- `annotations` is the only artifact on a consumer's compile classpath: it publishes zero
+  dependencies (enforced by a `check` task) and targets Kotlin language/API 2.0. Adding a dependency
+  or raising that floor is a breaking change for consumers.
+- Both modules use `jvmToolchain(17)`. The toolchain sets `org.gradle.jvm.version` in the published
+  module metadata, so raising it breaks resolution on JDK 17 consumers (issue #152).
+- The processor matches `@Log`/`@AutoLog` by qualified name and must not depend on `:annotations`
+  outside tests. A `typealias` shim is not usable — KSP reports aliases under their own name.
+- Generation is project-wide (`All`) by default; `kotlinloggingextensions.mode` /
+  `.targets` narrow it. One file per package per source set:
+  `KotlinLoggingExtensions_<module>.kt`.
 
 ## General Coding Guidelines
 

--- a/docs/project-instructions.md
+++ b/docs/project-instructions.md
@@ -32,8 +32,9 @@ Always use the Gradle wrapper (`./gradlew`), never a system-installed Gradle.
 - `annotations` is the only artifact on a consumer's compile classpath: it publishes zero
   dependencies (enforced by a `check` task) and targets Kotlin language/API 2.0. Adding a dependency
   or raising that floor is a breaking change for consumers.
-- Both modules use `jvmToolchain(17)`. The toolchain sets `org.gradle.jvm.version` in the published
-  module metadata, so raising it breaks resolution on JDK 17 consumers (issue #152).
+- Every module uses `jvmToolchain(17)`. For the two published ones the toolchain sets
+  `org.gradle.jvm.version` in the module metadata, so raising it breaks resolution on JDK 17
+  consumers (issue #152).
 - The processor matches `@Log`/`@AutoLog` by qualified name and must not depend on `:annotations`
   outside tests. A `typealias` shim is not usable, because KSP reports aliases under their own name.
 - Generation is project-wide (`All`) by default; `kotlinloggingextensions.mode` /


### PR DESCRIPTION
## Motivation

`3.0.0` (#155) changed the module layout, the annotation name, the default generation mode and the JDK
floor, and only `README.md` followed. Everything else — the agent instruction files and all five issue
templates — still described the 2.x library, and parts of it pointed users at settings that are now
wrong.

Closes #162.

## Modification

- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactoring
- [ ] Other:

**`docs/project-instructions.md`** (the file `CLAUDE.md` and `AGENTS.md` both redirect to)

Adds the `:annotations` module, and records the invariants that CI enforces but the file never stated —
so the next edit that breaks one fails a build instead of a release:

- the annotations artifact must publish zero dependencies (#156) and stay on Kotlin language/API 2.0
- both modules stay on `jvmToolchain(17)`, because the toolchain is what gets published as
  `org.gradle.jvm.version` (#152)
- the processor matches `@Log`/`@AutoLog` by qualified name, so a `typealias` shim compiles and
  silently generates nothing (verified in #139)

**`.github/copilot-instructions.md`** — three modules, the `All`/`PackageScan`/`AnnotationOnly` modes,
JDK 17.

**`.github/ISSUE_TEMPLATE/version_compatibility.yml`** — the one that was actively harmful. It stated
`**Required versions**: Kotlin 2.1.21, KSP 2.1.21-2.0.2` and asked reporters to tick "upgrading Kotlin
to the required version (2.1.21)". Since #155 that is a *downgrade* instruction pointing at a version
we no longer single out. Replaced with the measured range (JDK 17+, Kotlin 2.0+, KSP matching Kotlin)
and a link to the README table.

Also adds a **JDK version input**. The #152 failure mode is a dependency-*resolution* error on JDK 17
whose message never mentions Kotlin, so the JDK is the first thing worth having on the report.

**`.github/ISSUE_TEMPLATE/bug_report.yml`**

The build-config placeholder was telling reporters to do the thing #155 set out to make impossible:

```diff
 ksp("io.github.doljae:kotlin-logging-extensions:3.0.0")
-implementation("io.github.doljae:kotlin-logging-extensions:3.0.0")
-implementation("io.github.oshai:kotlin-logging-jvm:7.0.7")
+kspTest("io.github.doljae:kotlin-logging-extensions:3.0.0") // if test classes use `log`
+implementation("io.github.oshai:kotlin-logging-jvm:8.0.4")
+
+// Only for AnnotationOnly / PackageScan modes, where you write @Log yourself.
+compileOnly("io.github.doljae:kotlin-logging-extensions-annotations:3.0.0")
```

The processor on the compile classpath is exactly the shape that dragged the processor's metadata
version onto the consumer's compiler. `kspTest` comes from #161. The prerequisite checkbox about
"exact Kotlin and KSP versions" becomes the actual requirement.

**`feature_request.yml`, `question.yml`** — same retired "exact versions" claim, same fix.

**`README.md`**

- logback `1.6.1` → `1.6.2`, which is where #159 moved the project.
- Documents where generated code lands. #147 made it one file per package and #153 added the
  source-set suffix, so it is now
  `build/generated/ksp/<source set>/kotlin/<package>/KotlinLoggingExtensions_<module>.kt`. Neither
  change was written down anywhere, and anyone looking for the old per-class files had nothing to go
  on.

**`.github/workflows/create-release-pr.yml`** — one pattern, included here rather than split out
because it is the direct consequence of the `bug_report.yml` edit above. The processor pattern
requires `kotlin-logging-extensions:` with the colon immediately after, so it never matched the
`-annotations` coordinate this PR introduces into the template; without its own pattern that line
would ship stale at the next release. Same gap #155 closed for the README.

## Result

- [ ] Tests added/updated
- [x] Manual testing completed
- [ ] `./gradlew test` passes
- [ ] `./gradlew ktlintCheck` passes

Docs only — no Kotlin source touched, so the Gradle tasks have nothing to say about this change beyond
what CI already runs.

What was actually verified:

- every `.github/**/*.yml` file parses (`yaml.safe_load` over the templates and workflows)
- the claims added to `docs/project-instructions.md` were read back out of the build scripts rather
  than recalled: `jvmToolchain(17)` in both modules, `languageVersion/apiVersion = KOTLIN_2_0` and
  `verifyPublishedMetadataHasNoDependencies` in `:annotations`, `LOGGER_GENERATION_ANNOTATIONS` matched
  by qualified name in `LoggerProcessor.kt`
- the generated-file path in the README was taken from the actual output tree
  (`workload/build/generated/ksp/{main,test}/kotlin/...`), not from the naming code alone

## Additional Notes

**Ordering trap worth knowing about.** `create-release-pr.yml` rewrites `placeholder:` lines in the
issue templates *by position* — 1 = library version, 2 = Kotlin, 3 = KSP, 4 = kotlin-logging. The new
JDK input in `version_compatibility.yml` is therefore placed **last**, with a comment saying why. Put
anywhere earlier, its placeholder gets overwritten with the kotlin-logging coordinate at the next
release.

Not done here: `scripts/release.sh` still derives its version suggestion from the Kotlin version, a
leftover from #155 that the workflow already fixed. Filed as #163 and handled separately, since it is a
release-path bug rather than documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
