### PR TITLE
fix(release): suggest versions by severity, not from the Kotlin version

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -89,7 +89,7 @@ check_github_cli() {
 
 # Function to suggest next version
 # Plain SemVer since 3.0.0: the library version no longer tracks the Kotlin version (issue #152),
-# so nothing here is derived from build.gradle.kts any more — same reasoning as create-release-pr.yml.
+# so nothing here is derived from build.gradle.kts any more (same reasoning as create-release-pr.yml).
 suggest_next_version() {
     local latest_tag=$(git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -88,14 +88,15 @@ check_github_cli() {
 }
 
 # Function to suggest next version
+# Plain SemVer since 3.0.0: the library version no longer tracks the Kotlin version (issue #152),
+# so nothing here is derived from build.gradle.kts any more — same reasoning as create-release-pr.yml.
 suggest_next_version() {
     local latest_tag=$(git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -1)
-    local build_kotlin=$(grep 'kotlin("jvm") version' build.gradle.kts | sed 's/.*version "\([^"]*\)".*/\1/')
 
     if [[ -z $latest_tag ]]; then
         echo
         print_info "No SemVer releases found"
-        print_info "Suggested first version: ${build_kotlin%.*}.0"
+        print_info "Suggested first version: 1.0.0"
         echo
         return
     fi
@@ -110,14 +111,11 @@ suggest_next_version() {
 
     echo
     print_info "Current latest version: $version"
-    print_info "build.gradle.kts Kotlin version: $build_kotlin"
     print_info ""
     print_info "Suggestions:"
-    print_info "  Patch (deps, fixes): $major.$minor.$((patch + 1))"
-    # A Kotlin minor-line bump starts a new library minor line, e.g. Kotlin 2.4.x -> 2.4.0
-    if [[ "${build_kotlin%.*}" != "$major.$minor" ]]; then
-        print_info "  Kotlin ${build_kotlin} line: ${build_kotlin%.*}.0"
-    fi
+    print_info "  Patch (deps, fixes):        $major.$minor.$((patch + 1))"
+    print_info "  Minor (new features):       $major.$((minor + 1)).0"
+    print_info "  Major (breaking changes):   $((major + 1)).0.0"
     echo
 }
 
@@ -163,7 +161,7 @@ main() {
     suggest_next_version
     
     # Get version from user
-    read -p "Enter version for release PR (e.g., 2.1.21-0.0.1): " version
+    read -p "Enter version for release PR (e.g., 3.1.0): " version
     
     if [[ -z $version ]]; then
         print_error "Version is required."


### PR DESCRIPTION
## Motivation

#155 removed the Kotlin-derived version suggestion from `create-release-pr.yml`, on the reasoning that
the library version no longer says anything about which Kotlin versions the artifact supports (#152).
`scripts/release.sh` — the local wrapper that triggers that same workflow — was not updated.

Closes #163.

## Modification

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other:

Dropped the `build.gradle.kts` read and replaced the suggestion logic with the same
patch / minor / major derivation the workflow already uses. The prompt example moves off the retired
`<kotlin>-<lib>` scheme (`2.1.21-0.0.1` → `3.1.0`); `validate_version` still *accepts* that format on
purpose, since tags in it exist.

## Result

- [ ] Tests added/updated
- [x] Manual testing completed
- [ ] `./gradlew test` passes
- [ ] `./gradlew ktlintCheck` passes

Shell only — no Gradle input changes. `bash -n` passes. The function was extracted and run against the
repo's real tag list, before and after.

**Before** (this is `main` today, latest tag `v3.0.0`, Kotlin `2.4.10`):

```
[INFO] Current latest version: 3.0.0
[INFO] build.gradle.kts Kotlin version: 2.4.10
[INFO] Suggestions:
[INFO]   Patch (deps, fixes): 3.0.1
[INFO]   Kotlin 2.4.10 line: 2.4.0
```

`2.4.0` is *below* the current release, and it revives exactly the version scheme #152 retired. Enter
it and the workflow accepts the format — `validate_version` only checks shape — so the guard that
catches it is the duplicate-tag check, not anything that understands ordering.

**After:**

```
[INFO] Current latest version: 3.0.0
[INFO] Suggestions:
[INFO]   Patch (deps, fixes):        3.0.1
[INFO]   Minor (new features):       3.1.0
[INFO]   Major (breaking changes):   4.0.0
```

A major bump is now suggestable at all, which it was not before — the case #155 itself needed.

## Additional Notes

Low severity on its own: the script only prints suggestions and the workflow validates the input. What
makes it worth fixing is where it sits — the one prompt a maintainer reads while choosing a release
number.

The first-release branch (`latest_tag` empty) now says `1.0.0` instead of deriving from the Kotlin
version, matching what `create-release-pr.yml` prints in the same situation. Unreachable here, since
tags exist; changed so the two stay in step.

Split out of #164 (docs drift) because this is a release-path bug rather than documentation. The two
branches are independent — neither depends on the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
