### PR TITLE
ci: put the maintainer and the linked issue's labels on every PR

### DIFF
--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -1,0 +1,81 @@
+name: PR Triage
+
+# Two things GitHub cannot do on its own:
+#
+#  1. Copy a linked issue's labels onto the PR. There is no native issue -> PR label inheritance,
+#     and actions/labeler works off changed paths, which is a different question.
+#  2. Put the maintainer on their own PR. CODEOWNERS already requests review from @doljae on every
+#     PR he did not write; the API rejects the self-request case outright
+#     ("Review cannot be requested from pull request author", HTTP 422). An assignee is the
+#     equivalent that GitHub does allow, so self-authored PRs get that instead.
+
+on:
+  pull_request_target:
+    types: [opened, reopened, edited, ready_for_review]
+
+permissions:
+  issues: read
+  pull-requests: write
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+
+    steps:
+    # No checkout on purpose. pull_request_target runs with a write token in the base repo's
+    # context, so running any code from the head branch would hand that token to the PR author.
+    # This job only calls the API, and the PR body reaches the shell as an environment variable
+    # rather than through ${{ }} interpolation, which would let a crafted body inject commands.
+    - name: Mirror linked issue labels, and set reviewer or assignee
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_REPO: ${{ github.repository }}
+        PR: ${{ github.event.pull_request.number }}
+        AUTHOR: ${{ github.event.pull_request.user.login }}
+        BODY: ${{ github.event.pull_request.body }}
+        MAINTAINER: doljae
+      run: |
+        set -euo pipefail
+
+        # GitHub's own closing keywords, same set it uses to link a PR to an issue.
+        issues=$(
+          printf '%s' "$BODY" \
+            | grep -oiE '\b(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+#[0-9]+' \
+            | grep -oE '[0-9]+' \
+            | sort -u
+        ) || true
+
+        if [ -z "$issues" ]; then
+          echo "No closing keyword in the PR body — no labels to mirror."
+        else
+          echo "Linked issues: $(echo "$issues" | tr '\n' ' ')"
+          # /issues/N answers for pull requests too, so a "Closes #<pr>" typo degrades to a no-op
+          # instead of failing the job.
+          labels=$(
+            for n in $issues; do
+              gh api "repos/${GH_REPO}/issues/${n}" --jq '.labels[].name' 2>/dev/null || true
+            done | sort -u
+          )
+
+          if [ -z "$labels" ]; then
+            echo "Linked issues carry no labels."
+          else
+            # One call per label: label names contain spaces ("good first issue"), and read -r
+            # keeps them intact where word splitting would not.
+            while IFS= read -r label; do
+              [ -n "$label" ] || continue
+              echo "Adding label: $label"
+              gh pr edit "$PR" --add-label "$label"
+            done <<< "$labels"
+          fi
+        fi
+
+        if [ "$AUTHOR" = "$MAINTAINER" ]; then
+          gh pr edit "$PR" --add-assignee "$MAINTAINER"
+        else
+          # Usually redundant — CODEOWNERS has already requested review by the time this runs —
+          # and it must not fail the job when the reviewer is present or the author lacks the
+          # permission to be requested.
+          gh pr edit "$PR" --add-reviewer "$MAINTAINER" \
+            || echo "Could not request review from ${MAINTAINER} (already requested, or not permitted)."
+        fi

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -46,7 +46,7 @@ jobs:
         ) || true
 
         if [ -z "$issues" ]; then
-          echo "No closing keyword in the PR body — no labels to mirror."
+          echo "No closing keyword in the PR body, so there are no labels to mirror."
         else
           echo "Linked issues: $(echo "$issues" | tr '\n' ' ')"
           # /issues/N answers for pull requests too, so a "Closes #<pr>" typo degrades to a no-op
@@ -73,7 +73,7 @@ jobs:
         if [ "$AUTHOR" = "$MAINTAINER" ]; then
           gh pr edit "$PR" --add-assignee "$MAINTAINER"
         else
-          # Usually redundant — CODEOWNERS has already requested review by the time this runs —
+          # Usually redundant, since CODEOWNERS has already requested review by the time this runs,
           # and it must not fail the job when the reviewer is present or the author lacks the
           # permission to be requested.
           gh pr edit "$PR" --add-reviewer "$MAINTAINER" \

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,8 @@
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
         "config:recommended"
+    ],
+    "labels": [
+        "dependency-upgrade"
     ]
 }


### PR DESCRIPTION
## Motivation

Every PR here should carry @doljae and the labels of the issue it closes. Neither happens on its own:
GitHub has no issue → PR label inheritance, and `actions/labeler` matches changed paths, which is a
different question.

Closes #166.

## Modification

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other:

**`.github/workflows/pr-triage.yml`** (new) — reads GitHub's own closing keywords out of the PR body,
copies those issues' labels onto the PR, then:

- author is @doljae → `--add-assignee doljae`
- anyone else → `--add-reviewer doljae`, failure tolerated

That split is not a preference. GitHub rejects the self-request outright:

```
$ gh api -X POST repos/doljae/kotlin-logging-extensions/pulls/164/requested_reviewers \
    -f 'reviewers[]=doljae'
HTTP 422: Review cannot be requested from pull request author.
```

CODEOWNERS (`* @doljae`) already handles everyone else — PR #160 shows `reviewers=doljae` with nobody
acting — so the `--add-reviewer` branch is a backstop and is allowed to fail.

**`renovate.json`** — `"labels": ["dependency-upgrade"]`. Renovate PRs carry no closing keyword, so the
workflow has nothing to read; Renovate labels its own PRs natively. `reviewers` is deliberately *not*
added: CODEOWNERS covers it already.

## Result

- [ ] Tests added/updated
- [x] Manual testing completed
- [ ] `./gradlew test` passes
- [ ] `./gradlew ktlintCheck` passes

No Gradle input touched. The script was extracted and run against this repository's real issues, with
the mutating `gh pr edit` calls stubbed:

| Body | Result |
|---|---|
| `Closes #162.` | → `documentation` |
| `Fixes #163 and closes #162, resolves #163` | → `bug`, `documentation` (deduped) |
| `just a body mentioning #162` | no linked issue, no labels |
| *(empty)* | no linked issue |
| `Closes #164` (a PR, not an issue) | no labels, no failure |
| ``Closes #162 `touch /tmp/pwned` $(touch /tmp/pwned2) ; echo HACKED`` | → `documentation`; **neither file created** |

The last row is the one that matters. `pull_request_target` runs in the base repo's context with a
write token, so this job:

- does **no checkout** — no head-branch code executes
- calls the API only
- takes the PR body through `env:`, never `${{ }}` interpolation, which is what makes the injection
  row a no-op

`--add-label` is called once per label rather than batched, because label names contain spaces
(`good first issue`) and word splitting would shred them.

## Additional Notes

Since this cannot run on its own PR until it is on `main`, the first real exercise will be the next PR
opened after merge. If it misbehaves the blast radius is a wrong label.

`edited` is in the trigger list so that adding `Closes #N` to an existing PR still applies the labels;
re-runs are idempotent.

One consequence worth agreeing to: a fork contributor can put `Closes #N` in their own PR body and get
that issue's labels copied onto it. It costs a label on their own PR and nothing else, and the
alternative is not applying labels for outside contributions at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
