### PR TITLE
docs: correct the security policy, CODEOWNERS and code of conduct

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,20 +1,12 @@
-# Global ownership - all files require review from the project maintainer
+# One owner, every file.
+#
+# The per-path rules that used to follow this line all named @doljae as well, so none of them ever
+# changed the outcome — and the list had gone stale without anyone noticing: it pointed at
+# /.github/CODEOWNERS, a path that does not exist (this file lives at the repo root), and never
+# gained /annotations/ when that module was added in #155. A list that can rot unnoticed is a list
+# that was not doing anything.
+#
+# GitHub never requests review from a PR's own author, so this fires on PRs from others — Renovate,
+# outside contributors. Self-authored PRs get @doljae as assignee instead, via
+# .github/workflows/pr-triage.yml.
 * @doljae
-
-# Critical files that always require careful review
-/.github/workflows/ @doljae
-/gradle/ @doljae
-/build.gradle.kts @doljae
-/settings.gradle.kts @doljae
-/gradle.properties @doljae
-
-# Release and deployment related files
-/scripts/ @doljae
-/.github/CODEOWNERS @doljae
-
-# Security related files
-/SECURITY.md @doljae
-/.github/ISSUE_TEMPLATE/ @doljae
-
-# Core processor implementation
-/processor/src/main/kotlin/ @doljae 

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,12 +1,12 @@
 # One owner, every file.
 #
 # The per-path rules that used to follow this line all named @doljae as well, so none of them ever
-# changed the outcome — and the list had gone stale without anyone noticing: it pointed at
+# changed the outcome, and the list had gone stale without anyone noticing: it pointed at
 # /.github/CODEOWNERS, a path that does not exist (this file lives at the repo root), and never
 # gained /annotations/ when that module was added in #155. A list that can rot unnoticed is a list
 # that was not doing anything.
 #
-# GitHub never requests review from a PR's own author, so this fires on PRs from others — Renovate,
-# outside contributors. Self-authored PRs get @doljae as assignee instead, via
+# GitHub never requests review from a PR's own author, so this fires on PRs from others (Renovate,
+# outside contributors). Self-authored PRs get @doljae as assignee instead, via
 # .github/workflows/pr-triage.yml.
 * @doljae

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,83 @@
-## Code of Conduct
+# Contributor Covenant Code of Conduct
 
-This project and the corresponding community are governed by the [JetBrains Open Source and Community Code of Conduct](https://github.com/jetbrains#code-of-conduct).
-Please make sure you read it.
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at [seok9211@naver.com](mailto:seok9211@naver.com). All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 
-Security fixes land on the current minor line. Older lines are not backported — this is a
+Security fixes land on the current minor line. Older lines are not backported: this is a
 single-maintainer project, and pretending otherwise would be a promise it cannot keep.
 
 | Version | Supported          |
@@ -20,12 +20,12 @@ supports.
 
 ### How to Report
 
-**Preferred — GitHub private vulnerability reporting**: open the repository's
+**Preferred: GitHub private vulnerability reporting**: open the repository's
 [Security tab](https://github.com/doljae/kotlin-logging-extensions/security) and choose *Report a
 vulnerability*. The report stays private, the discussion stays attached to the repository, and a fix
 can be published as a GitHub Security Advisory with a CVE.
 
-**Alternative — email**: [seok9211@naver.com](mailto:seok9211@naver.com), subject line
+**Alternative: email**: [seok9211@naver.com](mailto:seok9211@naver.com), subject line
 "Security Vulnerability Report".
 
 Either way, please include:
@@ -71,7 +71,7 @@ Two artifacts are published, and what each one declares is checked rather than a
 | `kotlin-logging-extensions-annotations` | none |
 
 The annotations artifact is the only one that lands on your **compile** classpath, and it publishes
-zero dependencies — enforced on every build by `verifyPublishedMetadataHasNoDependencies`, which
+zero dependencies, enforced on every build by `verifyPublishedMetadataHasNoDependencies`, which
 fails the build if a dependency ever appears in the POM or Gradle module metadata (#156).
 
 kotlin-logging itself is **not** a dependency of either artifact. The processor declares it

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,26 +2,38 @@
 
 ## Supported Versions
 
-We release patches for security vulnerabilities. Which versions are eligible for receiving such patches depends on the CVSS v3.0 Rating:
+Security fixes land on the current minor line. Older lines are not backported — this is a
+single-maintainer project, and pretending otherwise would be a promise it cannot keep.
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 0.0.x   | :white_check_mark: |
+| `3.x`   | :white_check_mark: |
+| `< 3.0` | :x:                |
+
+Releases follow plain SemVer from `3.0.0`; the version no longer tracks your Kotlin version. See the
+[compatibility table](README.md#-version-compatibility) for the Kotlin, KSP and JDK range a release
+supports.
 
 ## Reporting a Vulnerability
-
-If you discover a security vulnerability, we would like to know about it so we can take steps to address it as quickly as possible.
 
 **Please do NOT report security vulnerabilities through public GitHub issues.**
 
 ### How to Report
 
-1. **Email**: Send an email to [seok9211@naver.com](mailto:seok9211@naver.com) with the subject line "Security Vulnerability Report"
-2. **Include**: 
-   - Description of the vulnerability
-   - Steps to reproduce the issue
-   - Potential impact
-   - Any suggested fixes (if available)
+**Preferred — GitHub private vulnerability reporting**: open the repository's
+[Security tab](https://github.com/doljae/kotlin-logging-extensions/security) and choose *Report a
+vulnerability*. The report stays private, the discussion stays attached to the repository, and a fix
+can be published as a GitHub Security Advisory with a CVE.
+
+**Alternative — email**: [seok9211@naver.com](mailto:seok9211@naver.com), subject line
+"Security Vulnerability Report".
+
+Either way, please include:
+
+- Description of the vulnerability
+- Steps to reproduce the issue
+- Potential impact
+- Any suggested fixes (if available)
 
 ### What to Expect
 
@@ -43,16 +55,28 @@ When using kotlin-logging-extensions:
 
 ## Security Features
 
-- **No runtime dependencies**: The processor only runs at compile time
-- **Minimal code generation**: Only generates simple logger property extensions
-- **No network access**: The processor doesn't make external connections
-- **No file system access**: Beyond standard KSP operations for code generation
+- **Nothing we publish reaches your application's runtime**: the processor is applied through
+  `ksp(...)`, so it and its dependencies live on the KSP classpath and run only during compilation
+- **Minimal code generation**: only simple logger property extensions
+- **No network access**: the processor doesn't make external connections
+- **No file system access**: beyond standard KSP operations for code generation
 
 ## Dependencies
 
-This project uses minimal dependencies to reduce the attack surface:
+Two artifacts are published, and what each one declares is checked rather than asserted:
 
-- Kotlin Symbol Processing (KSP) API - for compile-time code generation
-- kotlin-logging - for runtime logging functionality
+| Artifact | Declared dependencies |
+|---|---|
+| `kotlin-logging-extensions` (the processor) | `com.google.devtools.ksp:symbol-processing-api`, `org.jetbrains.kotlin:kotlin-stdlib` |
+| `kotlin-logging-extensions-annotations` | none |
 
-We regularly monitor our dependencies for known vulnerabilities and update them promptly when security patches are available. 
+The annotations artifact is the only one that lands on your **compile** classpath, and it publishes
+zero dependencies — enforced on every build by `verifyPublishedMetadataHasNoDependencies`, which
+fails the build if a dependency ever appears in the POM or Gradle module metadata (#156).
+
+kotlin-logging itself is **not** a dependency of either artifact. The processor declares it
+`compileOnly` and the generated code references it, so the version on your classpath is the one you
+chose.
+
+We regularly monitor our dependencies for known vulnerabilities and update them promptly when
+security patches are available.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,12 +20,12 @@ supports.
 
 ### How to Report
 
-**Preferred: GitHub private vulnerability reporting**: open the repository's
+**Preferred, GitHub private vulnerability reporting.** Open the repository's
 [Security tab](https://github.com/doljae/kotlin-logging-extensions/security) and choose *Report a
 vulnerability*. The report stays private, the discussion stays attached to the repository, and a fix
 can be published as a GitHub Security Advisory with a CVE.
 
-**Alternative: email**: [seok9211@naver.com](mailto:seok9211@naver.com), subject line
+**Alternative, email.** [seok9211@naver.com](mailto:seok9211@naver.com), subject line
 "Security Vulnerability Report".
 
 Either way, please include:


### PR DESCRIPTION
## Motivation

The governance files had drifted or were never right — most visibly, `SECURITY.md` told reporters that
`0.0.x` is the supported version, and its dependency section named a dependency this project does not
publish. Reviewed all four files; three needed work.

Closes #167.

## Modification

- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactoring
- [ ] Other:

**`SECURITY.md`**

- Support table `0.0.x` → `3.x` ✅ / `< 3.0` ❌. No release ever used `0.0.x`; current is `3.0.0`.
- Private vulnerability reporting is now the preferred channel, email the alternative. **The setting is
  already enabled on the repository** (`PUT /repos/.../private-vulnerability-reporting` → `enabled:
  true`), so the Security tab link in the doc works the moment this merges.
- The dependency section is rewritten from the *generated POMs*, not from memory:

  | Artifact | Published dependencies |
  |---|---|
  | `kotlin-logging-extensions` | `symbol-processing-api`, `kotlin-stdlib` |
  | `kotlin-logging-extensions-annotations` | none |

  The old text listed "kotlin-logging — for runtime logging functionality" as a dependency. It is not
  one: `:processor` declares it `compileOnly`, so it never reaches the published metadata. The doc now
  says so explicitly, since this is the section a supply-chain reviewer reads.
- "No runtime dependencies" → "Nothing we publish reaches your application's runtime", which is the
  accurate claim: the processor sits on the KSP classpath.
- Notes the `verifyPublishedMetadataHasNoDependencies` check from #156 that keeps the annotations
  artifact at zero dependencies.

**`CODEOWNERS`** — `* @doljae` plus a comment, down from that same line followed by eight per-path
rules that all named `@doljae` too. None of them ever changed an outcome. The proof they were inert is
that they had rotted unnoticed: one pointed at `/.github/CODEOWNERS`, a path that does not exist (this
file is at the repo root), and none was added for `/annotations/` when #155 created the module.

**`CODE_OF_CONDUCT.md`** — Contributor Covenant 2.1, replacing four lines pointing at the **JetBrains**
Open Source Code of Conduct. This is an unaffiliated personal project: there was nobody to report to
and JetBrains has no standing here. Enforcement contact is seok9211@naver.com, the address already in
`SECURITY.md`.

**`LICENSE`** — reviewed, **not changed**. Apache 2.0 full text, `Copyright 2025 Seokjae Lee`,
consistent with `inceptionYear = 2025` in both published POMs. Recorded in #167 so it is not re-checked.

## Result

- [ ] Tests added/updated
- [x] Manual testing completed
- [ ] `./gradlew test` passes
- [ ] `./gradlew ktlintCheck` passes

No Gradle input touched. Verification done:

- Both POMs generated (`./gradlew generatePomFileFor...`) and read, rather than inferring the
  dependency table from the build scripts.
- The Covenant text was fetched from `EthicalSource/contributor_covenant` at `release`, TOML front
  matter stripped, and the substitution asserted — the script failed the build unless
  `[INSERT CONTACT METHOD]` appeared exactly once. No hand-typed clauses.
- Private vulnerability reporting confirmed enabled via the API before writing the doc that points at
  it.

## Additional Notes

Worth confirming you are happy with two things, both easy to change:

1. **The Covenant's enforcement section commits you to a process** — reviewing reports, confidentiality,
   and a four-step consequence ladder. It is the standard expectation for an OSS project of this size,
   but it is a commitment made in your name.
2. **`seok9211@naver.com` is now published in one more place.** It was already in `SECURITY.md`; if
   you would rather route conduct reports somewhere else, that is a one-line change.

Adopting the Covenant also completes GitHub's community profile, which previously did not recognise
the JetBrains pointer as a code of conduct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
