### PR TITLE
feat(processor): select subclasses of a selected class

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,10 @@ That's it! The logger is generated using the fully qualified class name as the l
 ### Scoping Generation
 
 By default every class gets a `log` extension. If you want to narrow that, set a mode in
-`build.gradle.kts`.
+`build.gradle.kts`. A mode picks a **starting set** of classes; subclasses of anything in that set
+come along, for the reason described under [Subclasses](#subclasses) below.
 
-**Limit to specific packages** — `PackageScan`:
+**Start from specific packages** — `PackageScan`:
 
 ```kotlin
 ksp {
@@ -121,7 +122,7 @@ Target rules:
 - Invalid target entries are ignored with a warning
 - If `kotlinloggingextensions.targets` is set without `mode`, package scanning is enabled automatically when at least one valid target exists
 
-**Limit to explicitly marked classes** — `AnnotationOnly`:
+**Start from classes you mark** — `AnnotationOnly`:
 
 ```kotlin
 ksp {
@@ -149,6 +150,23 @@ class OrderProcessor {
 `@Log` also works in `PackageScan` mode, where a class gets a logger if **either** condition
 matches. Mode values are case/`_`/`-` insensitive: `All` (default), `PackageScan`, `AnnotationOnly`.
 
+#### Subclasses
+
+**A subclass of a selected class is selected too**, transitively, in both modes — even when it is
+unannotated or lives outside every scanned package.
+
+This is not the modes being generous. A Kotlin extension accepts subtypes, so `log` inside a
+subclass resolves to the superclass's extension whether or not this library generates anything for
+it. There is no "the subclass has no `log`" outcome to choose; the only choice is between the
+subclass logging under **its own** name and logging under its **superclass's** name, silently. It
+gets its own.
+
+The practical consequence is that marking a widely-extended base class or interface pulls its whole
+hierarchy in. If you want a narrower generated surface, mark leaf classes rather than base ones.
+
+The superclass has to be in the same compilation. A superclass from a **dependency** is matched only
+by `PackageScan`, because `@Log` is `SOURCE`-retained and is not in the published class file.
+
 > **Only the annotations artifact belongs on the compile classpath.** The processor is wired in
 > through `ksp(...)` and never needs to be visible to your compiler — putting it in `compileOnly`
 > narrows which Kotlin versions can build against it.
@@ -156,7 +174,7 @@ matches. Mode values are case/`_`/`-` insensitive: `All` (default), `PackageScan
 ## ✨ Features
 
 - **🔧 Zero Boilerplate**: No logger declarations, no annotations, no configuration — just use `log.info { }`
-- **🎚️ Scope It When You Want To**: Narrow generation to specific packages (`PackageScan`) or to explicitly marked classes (`AnnotationOnly`)
+- **🎚️ Scope It When You Want To**: Narrow generation to specific packages (`PackageScan`) or to classes you mark (`AnnotationOnly`), with their subclasses
 - **⚡ Compile-time Generation**: Uses KSP for compile-time safety with zero runtime overhead
 - **📦 Package-aware Naming**: Logger names automatically match fully qualified class names
 - **🏗️ kotlin-logging Integration**: Works seamlessly with the standard kotlin-logging library

--- a/processor/src/main/kotlin/io/github/doljae/kotlinlogging/extensions/LoggerProcessor.kt
+++ b/processor/src/main/kotlin/io/github/doljae/kotlinlogging/extensions/LoggerProcessor.kt
@@ -89,6 +89,40 @@ class LoggerProcessor(
             return true
         }
 
+        return isGenerationTarget()
+    }
+
+    /**
+     * True when this class is selected by the configured mode, or inherits from a class that is.
+     *
+     * An extension receiver accepts subtypes, so a `log` generated for a superclass also resolves
+     * inside its subclasses — under the *superclass's* name. [LoggerGenerationMode.ALL] never shows
+     * this, because the subclass has an extension of its own and the more specific receiver wins. In
+     * the other modes a subclass that is not itself selected would silently log under its
+     * superclass's name, which is the one thing this library exists to get right. So a subclass of a
+     * target is a target.
+     *
+     * That grants no logging the class did not already have — it only stops it reporting a name that
+     * is not its own.
+     *
+     * A superclass from a dependency cannot be recognised by annotation: [Log] is `SOURCE`-retained,
+     * so it is not in the class file. Only [LoggerGenerationMode.PACKAGE_SCAN] still matches those,
+     * by package name.
+     */
+    private fun KSClassDeclaration.isGenerationTarget(): Boolean {
+        if (isSelectedByMode()) {
+            return true
+        }
+
+        return superTypes.any { superTypeReference ->
+            val superType = superTypeReference.resolve().declaration as? KSClassDeclaration ?: return@any false
+            // Every class lists Any, so treating it as a target would select the whole module.
+            superType.qualifiedName?.asString() != ANY_QUALIFIED_NAME && superType.isGenerationTarget()
+        }
+    }
+
+    /** Whether the configured mode selects this class on its own, ignoring what it inherits from. */
+    private fun KSClassDeclaration.isSelectedByMode(): Boolean {
         if (hasLoggerGenerationAnnotation()) {
             return true
         }
@@ -345,6 +379,8 @@ class LoggerProcessor(
                 "io.github.doljae.kotlinlogging.extensions.Log",
                 "io.github.doljae.kotlinlogging.extensions.AutoLog",
             )
+
+        private const val ANY_QUALIFIED_NAME = "kotlin.Any"
 
         // Ref: https://kotlinlang.org/docs/keyword-reference.html
         private val hardKeywords =

--- a/processor/src/test/kotlin/io/github/doljae/kotlinlogging/extensions/LoggerProcessorTest.kt
+++ b/processor/src/test/kotlin/io/github/doljae/kotlinlogging/extensions/LoggerProcessorTest.kt
@@ -1065,6 +1065,138 @@ class LoggerProcessorTest {
     }
 
     @Test
+    fun `should generate log extension for a subclass of an annotated class`() {
+        // Without this, 'Sub' has no extension of its own, so 'log' resolves to the one generated for
+        // 'Base' — the subclass silently logs under its superclass's name.
+        val source =
+            SourceFile.kotlin(
+                "Hierarchy.kt",
+                """
+                package com.example
+                import io.github.doljae.kotlinlogging.extensions.Log
+
+                @Log
+                open class Base
+
+                class Sub : Base()
+
+                class Unrelated
+                """.trimIndent(),
+            )
+
+        val compilation =
+            KotlinCompilation().apply {
+                sources = listOf(source)
+                configureKsp {
+                    symbolProcessorProviders += LoggerProcessorProvider()
+                }
+                kspProcessorOptions = mutableMapOf(LoggerProcessor.GENERATION_MODE_OPTION_KEY to "AnnotationOnly")
+                inheritClassPath = true
+            }
+
+        val result = compilation.compile()
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+
+        val generated = compilation.generatedExtensionsFileContaining("Base")?.readText()
+
+        generated shouldContain "KotlinLogging.logger(\"com.example.Base\")"
+        generated shouldContain "KotlinLogging.logger(\"com.example.Sub\")"
+        generated shouldNotContain "Unrelated"
+    }
+
+    @Test
+    fun `should generate log extension through a chain of unannotated subclasses`() {
+        val source =
+            SourceFile.kotlin(
+                "DeepHierarchy.kt",
+                """
+                package com.example
+                import io.github.doljae.kotlinlogging.extensions.Log
+
+                interface Marker
+
+                @Log
+                interface Contract
+
+                open class Middle : Marker, Contract
+
+                class Leaf : Middle()
+                """.trimIndent(),
+            )
+
+        val compilation =
+            KotlinCompilation().apply {
+                sources = listOf(source)
+                configureKsp {
+                    symbolProcessorProviders += LoggerProcessorProvider()
+                }
+                kspProcessorOptions = mutableMapOf(LoggerProcessor.GENERATION_MODE_OPTION_KEY to "AnnotationOnly")
+                inheritClassPath = true
+            }
+
+        val result = compilation.compile()
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+
+        val generated = compilation.generatedExtensionsFileContaining("Contract")?.readText()
+
+        generated shouldContain "KotlinLogging.logger(\"com.example.Middle\")"
+        generated shouldContain "KotlinLogging.logger(\"com.example.Leaf\")"
+        // 'Marker' is a supertype of a target, not a subtype of one — nothing inherits from it.
+        generated shouldNotContain "Marker.log"
+    }
+
+    @Test
+    fun `should generate log extension for a subclass outside every scanned package`() {
+        val source =
+            SourceFile.kotlin(
+                "ScannedHierarchy.kt",
+                """
+                package com.example.auto
+
+                open class ScannedBase
+                """.trimIndent(),
+            )
+        val outside =
+            SourceFile.kotlin(
+                "OutsideHierarchy.kt",
+                """
+                package com.example.manual
+                import com.example.auto.ScannedBase
+
+                class OutsideSub : ScannedBase()
+
+                class OutsideOnly
+                """.trimIndent(),
+            )
+
+        val compilation =
+            KotlinCompilation().apply {
+                sources = listOf(source, outside)
+                configureKsp {
+                    symbolProcessorProviders += LoggerProcessorProvider()
+                }
+                kspProcessorOptions =
+                    mutableMapOf(
+                        LoggerProcessor.GENERATION_MODE_OPTION_KEY to "PackageScan",
+                        LoggerProcessor.PACKAGE_SCAN_TARGETS_OPTION_KEY to "com.example.auto.*",
+                    )
+                inheritClassPath = true
+            }
+
+        val result = compilation.compile()
+        result.exitCode shouldBe KotlinCompilation.ExitCode.OK
+
+        compilation.generatedExtensionsFileContaining("ScannedBase")?.readText() shouldContain
+            "KotlinLogging.logger(\"com.example.auto.ScannedBase\")"
+
+        val outsideGenerated = compilation.generatedExtensionsFileContaining("OutsideSub")?.readText()
+
+        outsideGenerated shouldContain "package com.example.manual"
+        outsideGenerated shouldContain "KotlinLogging.logger(\"com.example.manual.OutsideSub\")"
+        outsideGenerated shouldNotContain "OutsideOnly"
+    }
+
+    @Test
     fun `should derive a file name discriminator that separates source sets`() {
         // Gradle reports 'group:project' for main and 'group:project_test' for the test compilation,
         // which is the only signal KSP exposes that tells the two compilations apart.


### PR DESCRIPTION
## Motivation

`AnnotationOnly` used to mean "only the classes you mark", and that reading has no way to be
correct. An extension receiver accepts subtypes, so `log` written inside an unmarked subclass of a
marked class still compiles — resolving to the **superclass's** extension, and logging under the
superclass's name with no diagnostic.

There is no "the subclass has no `log`" outcome available to choose. The only two reachable ones are
the subclass logging under its own name, or under its superclass's name silently. It now gets its
own.

| call | before | after |
| --- | --- | --- |
| `Base().who()` | `Base` | `Base` |
| `Sub().who()` | `Base` | `Base` |
| `Sub().mine()` | **`Base`** | **`Sub`** |

`All` mode never showed this: every subclass already had its own extension and the more specific
receiver wins.

Closes #173

## Modification

### What changes

A mode now picks a **starting set** of classes rather than the final set: a subclass of a selected
class is selected too, transitively, in both `AnnotationOnly` and `PackageScan`.

### How

`shouldAutoLog()` short-circuits `All` and otherwise delegates to a recursive
`isGenerationTarget()`: a class is a target if the mode selects it, **or** any supertype is a
target. `kotlin.Any` is skipped, or a pathological `kotlin.*` scan pattern would select every class
in the module.

### Cost

This widens both modes, so it is a design change and not a bug fix. Marking a widely-extended base
class — or an interface — now pulls its whole hierarchy in, including subclasses that never call
`log`. Anyone using a mode to keep the generated surface small will see it grow; the answer is to
mark leaf classes rather than base ones. Written down in the README rather than left to be
discovered.

### Limitations kept

**A superclass from a dependency** cannot be recognised by annotation: `@Log` is
`@Retention(SOURCE)`, so it is not in the published class file. Only `PackageScan` still matches
those, by package name. Documented in the README alongside the new behaviour.

**A `private`, `protected`, or local subclass is still not fixed by this change.** It is selected by
`isGenerationTarget()`, and then `buildExtension()` drops it: `getVisibilityModifier()` returns
`null` for those, because an extension is written to a separate file and cannot name a receiver type
that is not visible there.

```kotlin
@Log
open class Base

private class Hidden : Base() {
    fun mine() = log.name    // still "Base"
}
```

So the symptom this PR removes survives for exactly the classes the processor already skips, and it
stays silent. That is the same skip #170 wants a warning for and #171 wants documented; this PR does
not widen or narrow it.

### Docs

`### Scoping Generation` reworded — "Limit to …" became "Start from …" for both modes — plus a new
`#### Subclasses` subsection covering the rule, the cost, and the dependency limit. The Features
bullet now says "with their subclasses".

## Result

Three new tests in `LoggerProcessorTest`, all verified to fail with the processor change stashed and
pass with it:

- annotated parent + unannotated subclass in `AnnotationOnly`, with an unrelated class asserted absent
- transitive chain `Leaf : Middle : Contract`, asserting a *supertype* of a target (`Marker`) is not selected
- `PackageScan` where the parent is inside the scanned package and the subclass is in a different one

`./gradlew build` green (31 processor tests, up from 28).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
