### PR TITLE
docs: describe generation as class-driven in the Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ dependencies {
 
 **Step 2: Use `log`**
 
-Nothing to annotate, nothing to configure:
+Nothing to annotate, nothing to configure. Every class in a processed source set already has a
+`log`, so just call it:
 
 ```kotlin
 class OrderProcessor {
@@ -87,21 +88,37 @@ class OrderProcessor {
 }
 ```
 
-**Step 3: Generate Logger Code**
+**Step 3: Build as usual**
 
-After writing your code, run KSP to generate the logger extensions:
+```bash
+./gradlew build
+```
+
+KSP runs ahead of the Kotlin compiler within the same build, so the extensions are generated and the
+code that uses them is compiled in one pass. There is no separate generation step to run first, and
+no point at which your code is written but the extension is missing.
+
+That's it! The logger is named after the fully qualified class name.
+
+### How Generation Is Decided
+
+The processor never looks at where you call `log`. On every build it walks the *class declarations*
+in the source set and writes a `log` extension for each class that qualifies, whether or not that
+class logs anything. A class that already declares its own `log` (on the class or on its companion)
+is skipped, so a hand-written logger always wins.
+
+Output lands in `build/generated/ksp/<source set>/kotlin`, one file per package named
+`KotlinLoggingExtensions_<module>.kt`. The module suffix is what keeps `main` and `test` from
+colliding when they share a package. To regenerate without a full build, run the KSP tasks directly:
 
 ```bash
 ./gradlew kspKotlin kspTestKotlin
 ```
 
-This will generate the `log` property and resolve any compilation errors in your IDE.
-
-That's it! The logger is generated using the fully qualified class name as the logger name.
-
-Output lands in `build/generated/ksp/<source set>/kotlin`, one file per package named
-`KotlinLoggingExtensions_<module>.kt`. The module suffix is what keeps `main` and `test` from
-colliding when they share a package.
+Your IDE is the one place where the ordering is visible: it cannot resolve `log` until a build has
+produced the generated sources and it has indexed them. That is an indexing lag, not a missing
+generation step, and it is covered under
+[Troubleshooting & IDE Support](#-troubleshooting--ide-support).
 
 ### Scoping Generation
 

--- a/README.md
+++ b/README.md
@@ -68,10 +68,24 @@ dependencies {
 }
 ```
 
-**Step 2: Use `log`**
+**Step 2: Generate the extensions**
 
-Nothing to annotate, nothing to configure. Every class in a processed source set already has a
-`log`, so just call it:
+```bash
+./gradlew build
+```
+
+KSP runs ahead of the Kotlin compiler inside the same build, so `build` generates and compiles in one
+pass. To generate without a full build, run the KSP tasks directly:
+
+```bash
+./gradlew kspKotlin kspTestKotlin
+```
+
+Either way, once this finishes every class in a processed source set has a `log`.
+
+**Step 3: Use `log`**
+
+Nothing to annotate, nothing to configure. The extension is already there, so just call it:
 
 ```kotlin
 class OrderProcessor {
@@ -88,16 +102,6 @@ class OrderProcessor {
 }
 ```
 
-**Step 3: Build as usual**
-
-```bash
-./gradlew build
-```
-
-KSP runs ahead of the Kotlin compiler within the same build, so the extensions are generated and the
-code that uses them is compiled in one pass. There is no separate generation step to run first, and
-no point at which your code is written but the extension is missing.
-
 That's it! The logger is named after the fully qualified class name.
 
 ### How Generation Is Decided
@@ -109,15 +113,11 @@ is skipped, so a hand-written logger always wins.
 
 Output lands in `build/generated/ksp/<source set>/kotlin`, one file per package named
 `KotlinLoggingExtensions_<module>.kt`. The module suffix is what keeps `main` and `test` from
-colliding when they share a package. To regenerate without a full build, run the KSP tasks directly:
+colliding when they share a package.
 
-```bash
-./gradlew kspKotlin kspTestKotlin
-```
-
-Your IDE is the one place where the ordering is visible: it cannot resolve `log` until a build has
-produced the generated sources and it has indexed them. That is an indexing lag, not a missing
-generation step, and it is covered under
+A class you write *after* the last build has no extension yet, so run Step 2 again and your IDE will
+resolve `log` once it has indexed the new sources. That is an indexing lag, not a missing generation
+step, and it is covered under
 [Troubleshooting & IDE Support](#-troubleshooting--ide-support).
 
 ### Scoping Generation

--- a/README.md
+++ b/README.md
@@ -75,13 +75,11 @@ dependencies {
 ```
 
 KSP runs ahead of the Kotlin compiler inside the same build, so `build` generates and compiles in one
-pass. To generate without a full build, run the KSP tasks directly:
+pass. Run `./gradlew kspKotlin kspTestKotlin` instead if you only want the generated sources without
+a full build.
 
-```bash
-./gradlew kspKotlin kspTestKotlin
-```
-
-Either way, once this finishes every class in a processed source set has a `log`.
+Every class that already exists in a processed source set has a `log` once this finishes, so the call
+sites you write next resolve straight away.
 
 **Step 3: Use `log`**
 


### PR DESCRIPTION
## Motivation

The Quick Start usage guide was ordered "Step 2: use `log`" then "Step 3: Generate Logger Code", with
the line *"This will generate the `log` property and resolve any compilation errors in your IDE."*
Read in order, that describes a workflow that does not exist: write `log` by hand, sit on a compile
error, then run a KSP task to make the error go away. It reads as if the processor picks up
unresolved `log` references and back-fills them.

`LoggerProcessor.process()` does the opposite. It walks the class declarations in the source set and
writes a `log` extension for every class that qualifies, whether or not that class logs anything, and
skips any class that already declares its own `log`. Call sites are never inspected. KSP also runs
ahead of the Kotlin compiler inside the same build, so `./gradlew build` generates and compiles in
one pass and there is no separate command to remember.

Closes #177.

## Modification

- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactoring
- [ ] Other:

**`README.md`**, Quick Start only:

- The three steps are reordered to **add the dependency → run `build` (or the `ksp*` tasks) → use
  `log`**. The old order told you to write `log` first and build afterwards, which is the one path
  that does show you an unresolved reference. Because generation is class-driven, building first
  means `log` resolves from the very first call site you write.
- Step 2 leads with `./gradlew build` and mentions `./gradlew kspKotlin kspTestKotlin` inline as the
  "generated sources without a full build" escape hatch. A second code block gave it equal billing.
- Step 2 promises a `log` for every class that **already exists**. Unqualified, the sentence was
  wrong for a greenfield project: Step 2 generates nothing there, so the first class you write still
  shows an unresolved reference until the next build. That case is handled one section down rather
  than by hanging an exception off the third step of a Quick Start.
- New `### How Generation Is Decided` subsection: generation is driven by class declarations, not by
  call sites, and a hand-written `log` on the class or its companion wins.
- The IDE is named as an indexing lag on *newly written* classes (rerun Step 2), not as a build step,
  and linked to the existing Troubleshooting section.

## Result

- [ ] Tests added/updated
- [ ] Manual testing completed
- [ ] `./gradlew test` passes
- [ ] `./gradlew ktlintCheck` passes

README only, no Kotlin source touched, so the Gradle tasks have nothing to say about this change
beyond what CI already runs.

What was verified:

- The behavioural claims were read out of `processor/src/main/kotlin/io/github/doljae/kotlinlogging/extensions/LoggerProcessor.kt`,
  not recalled: `process()` builds its class list from `resolver.getNewFiles()` and filters on
  `shouldAutoLog()` / `hasDeclaredLogProperty()`, with no reference to usage sites;
  `hasDeclaredLogProperty()` covers the companion object as well as the class body.
- The task names are the real ones (`kspKotlin` / `kspTestKotlin`, matching the existing line at
  README "Troubleshooting"); there is no `kspCompile` task on the JVM target.
- The anchor `#-troubleshooting--ide-support` was taken from the live rendered README, not guessed.
  GitHub strips the emoji and the `&` from `## 🛠️ Troubleshooting & IDE Support`, which is where the
  leading hyphen and the doubled one come from.

## Additional Notes

The `### How Generation Is Decided` heading sits under `## 🚀 Quick Start`, alongside `How to Use` and
`Scoping Generation`. It is placed after the three steps on purpose: a reader following the steps does
not need it, and a reader who wants to know why building first is enough does.

Not changed here: the `What It Does` blurb and the Features list already describe generation
correctly, and `Scoping Generation` is about which classes qualify rather than about when generation
runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

