### PR TITLE
docs: write down the issue-first contribution workflow

### DIFF
--- a/docs/project-instructions.md
+++ b/docs/project-instructions.md
@@ -2,6 +2,38 @@
 
 KSP plugin that generates `kotlin-logging` `log` extensions at compile time.
 
+## Contribution Workflow
+
+Every change follows this order, and no step is skipped, not even for a one-line documentation fix:
+
+1. **Open an issue** stating the problem and the proposed change.
+2. **Branch off `main`** as `<type>/<slug>`, where `<type>` is the Conventional Commit type of the
+   work (`docs/quick-start-generation-model`, `fix/inherited-logger-name-173`).
+3. **Commit on that branch**, one logical change per commit, subject in Conventional Commit form.
+4. **Open a PR** whose body links the issue with `Closes #<number>`.
+
+Never commit to `main` or edit its working tree directly.
+
+Use the forms this repository already configures, and fill them in rather than replacing them with
+free-form text:
+
+- Issues: the templates in [`.github/ISSUE_TEMPLATE/`](../.github/ISSUE_TEMPLATE). Blank issues are
+  enabled for work that fits none of them, but they get the same level of detail.
+- PRs: [`.github/pull_request_template.md`](../.github/pull_request_template.md). Keep its headings
+  and answer each one.
+
+Two conventions above are load-bearing, not cosmetic:
+
+- `pr-triage.yml` parses the PR body for GitHub's closing keywords and mirrors the linked issue's
+  labels onto the PR. A body without `Closes #<number>` produces an unlabeled PR.
+- `create-release-pr.yml` groups release notes by commit subject prefix: `feat:`, `fix:`, `perf:`,
+  `refactor:` become "Features & Fixes", and `docs:`, `chore:`, `ci:`, `style:`, `test:` become
+  "Documentation & Maintenance". The patterns are unscoped, so anything else, a scoped
+  `docs(readme):` included, falls through to a default that files it under "Features & Fixes".
+
+Issue and PR bodies are where the reasoning behind a change is recorded, so state the mechanism and
+the evidence, not just what changed.
+
 ## Modules
 
 | Module | Purpose |


### PR DESCRIPTION
## Motivation

`docs/project-instructions.md` is the file both `CLAUDE.md` and `AGENTS.md` reduce to, so it is the
entry point for any assistant working here. It described the modules, the build commands, and the
KSP constraints, and said nothing about how a change actually reaches `main`.

The workflow was therefore only inferable from history, and nothing stated that the issue and PR
templates are mandatory rather than optional, even though `blank_issues_enabled: true` makes them
trivial to bypass.

Closes #181

## Modification

<!-- What was changed? -->

Added a `Contribution Workflow` section to `docs/project-instructions.md`, placed before `Modules`
because it governs everything that follows:

- the four steps: issue, branch off `main` as `<type>/<slug>`, commits, PR with `Closes #<number>`;
- never commit to `main` or edit its working tree directly;
- fill in `.github/ISSUE_TEMPLATE/` and `.github/pull_request_template.md` rather than replacing
  them with free-form text;
- the two conventions that are load-bearing rather than cosmetic: `pr-triage.yml` parses the PR body
  for closing keywords to mirror the linked issue's labels, and `create-release-pr.yml` groups
  release notes by unscoped commit subject prefix, defaulting anything unmatched into
  "Features & Fixes".

- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactoring
- [ ] Other: 

## Result

<!-- How was it tested/verified? -->

Every claim in the new section was read out of the file it names before being written down:
the closing-keyword parsing at `.github/workflows/pr-triage.yml`, and the prefix matching in
`.github/workflows/create-release-pr.yml`. Relative links resolve from `docs/` to `../.github/`.

No Kotlin, Gradle, or workflow file changed, so no build task was run.

- [ ] Tests added/updated
- [ ] Manual testing completed  
- [ ] `./gradlew test` passes
- [ ] `./gradlew ktlintCheck` passes

## Additional Notes

Branched from `main`, so it does not overlap #180, which slims the templates themselves. The new
section refers to the templates by path and never quotes their fields, so it stays correct after
#180 merges.

A root `CONTRIBUTING.md` for human contributors was left out on purpose: `CLAUDE.md` and `AGENTS.md`
already route here, so one file reaches every assistant, and a second copy would have to be kept in
sync. Worth adding when outside contributions actually start arriving.
