### PR TITLE
fix(ci): categorize scoped commits into the right release-notes section

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,9 @@ jobs:
       with:
         ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
       
+    - name: Check release-notes categorization
+      run: ./scripts/categorize-commit.sh --self-test
+
     - name: Setup Gradle
       uses: ./.github/actions/setup-gradle
       

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -421,28 +421,23 @@ jobs:
               
               echo "  Categorizing: $COMMIT_MSG"
               
-                             # Categorize commits
-               if [[ "$COMMIT_MSG" == fix\(deps\):* ]] || [[ "$COMMIT_MSG" == fix\(dep\):* ]] || 
-                  ([[ "$COMMIT_MSG" == chore:* ]] || [[ "$COMMIT_MSG" == ci:* ]]) && 
-                  ([[ "$COMMIT_MSG" == *update* ]] || [[ "$COMMIT_MSG" == *upgrade* ]] || [[ "$COMMIT_MSG" == *bump* ]]) && 
-                  ([[ "$COMMIT_MSG" == *dependency* ]] || [[ "$COMMIT_MSG" == *dependencies* ]] || [[ "$COMMIT_MSG" == *deps* ]] || 
-                   [[ "$COMMIT_MSG" == *version* ]] || [[ "$COMMIT_MSG" == *kotlin* ]] || [[ "$COMMIT_MSG" == *ksp* ]] || [[ "$COMMIT_MSG" == *gradle* ]]); then
-                 # Version & Dependency updates (check this first)
-                 VERSION_DEPS="${VERSION_DEPS}- ${COMMIT_MSG}"$'\n'
-                 echo "    → Dependencies & Versions"
-               elif [[ "$COMMIT_MSG" == feat:* ]] || [[ "$COMMIT_MSG" == fix:* ]] || [[ "$COMMIT_MSG" == perf:* ]] || [[ "$COMMIT_MSG" == refactor:* ]]; then
-                 # Features & Fixes
-                 FEATURES_FIXES="${FEATURES_FIXES}- ${COMMIT_MSG}"$'\n'
-                 echo "    → Features & Fixes"
-               elif [[ "$COMMIT_MSG" == docs:* ]] || [[ "$COMMIT_MSG" == chore:* ]] || [[ "$COMMIT_MSG" == ci:* ]] || [[ "$COMMIT_MSG" == style:* ]] || [[ "$COMMIT_MSG" == test:* ]]; then
-                 # Documentation & Maintenance
-                 DOCS_MAINTENANCE="${DOCS_MAINTENANCE}- ${COMMIT_MSG}"$'\n'
-                 echo "    → Documentation & Maintenance"
-               else
-                 # Uncategorized - put in Features & Fixes as default
-                 FEATURES_FIXES="${FEATURES_FIXES}- ${COMMIT_MSG}"$'\n'
-                 echo "    → Features & Fixes (default)"
-               fi
+              # scripts/categorize-commit.sh parses the Conventional Commit type and scope, so
+              # a scoped subject lands in the same section as its unscoped form. Run
+              # `scripts/categorize-commit.sh --self-test` after changing the rules; CI runs it too.
+              case "$(./scripts/categorize-commit.sh "$COMMIT_MSG")" in
+                deps)
+                  VERSION_DEPS="${VERSION_DEPS}- ${COMMIT_MSG}"$'\n'
+                  echo "    → Dependencies & Versions"
+                  ;;
+                docs)
+                  DOCS_MAINTENANCE="${DOCS_MAINTENANCE}- ${COMMIT_MSG}"$'\n'
+                  echo "    → Documentation & Maintenance"
+                  ;;
+                *)
+                  FEATURES_FIXES="${FEATURES_FIXES}- ${COMMIT_MSG}"$'\n'
+                  echo "    → Features & Fixes"
+                  ;;
+              esac
             fi
           done <<< "$ALL_COMMITS"
           

--- a/docs/project-instructions.md
+++ b/docs/project-instructions.md
@@ -26,10 +26,13 @@ Two conventions above are load-bearing, not cosmetic:
 
 - `pr-triage.yml` parses the PR body for GitHub's closing keywords and mirrors the linked issue's
   labels onto the PR. A body without `Closes #<number>` produces an unlabeled PR.
-- `create-release-pr.yml` groups release notes by commit subject prefix: `feat:`, `fix:`, `perf:`,
-  `refactor:` become "Features & Fixes", and `docs:`, `chore:`, `ci:`, `style:`, `test:` become
-  "Documentation & Maintenance". The patterns are unscoped, so anything else, a scoped
-  `docs(readme):` included, falls through to a default that files it under "Features & Fixes".
+- `create-release-pr.yml` groups release notes by commit subject, through
+  [`scripts/categorize-commit.sh`](../scripts/categorize-commit.sh): `feat`, `fix`, `perf`,
+  `refactor` become "Features & Fixes", `docs`, `chore`, `ci`, `style`, `test` become
+  "Documentation & Maintenance", and a `deps` scope becomes "Dependencies & Versions". A scope does
+  not change the section, but a subject that is not a Conventional Commit has no type to read and
+  defaults to "Features & Fixes". Run `scripts/categorize-commit.sh --self-test` after changing
+  those rules; CI runs it on every PR.
 
 Issue and PR bodies are where the reasoning behind a change is recorded, so state the mechanism and
 the evidence, not just what changed.

--- a/scripts/categorize-commit.sh
+++ b/scripts/categorize-commit.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+#
+# Categorize one commit subject into a release-notes section for create-release-pr.yml.
+#
+#   scripts/categorize-commit.sh "docs(readme): fix the table"   # prints: docs
+#   scripts/categorize-commit.sh --self-test                     # runs the table below
+#
+# Prints exactly one of: features | deps | docs.
+#
+# The type and scope are parsed once, so a Conventional Commit scope cannot change the section.
+# The workflow used to match whole subjects (`feat:*`, `docs:*`, ...), which left every scoped
+# subject to the uncategorized default, Features & Fixes, and announced `chore(deps):` Renovate
+# updates as features (issue #183).
+set -euo pipefail
+
+categorize() {
+  local subject="$1" type="" scope=""
+
+  # <type>[(scope)][!]: description. Held in a variable because bash 3.2, which is what macOS
+  # ships, does not accept the parentheses inline in the conditional.
+  local conventional='^([a-z]+)(\(([^)]*)\))?!?:'
+  if [[ "$subject" =~ $conventional ]]; then
+    type="${BASH_REMATCH[1]}"
+    scope="${BASH_REMATCH[3]}"
+  fi
+
+  local lower
+  lower="$(printf '%s' "$subject" | tr '[:upper:]' '[:lower:]')"
+
+  if [[ "$scope" == deps || "$scope" == dep ]]; then
+    # Renovate opens both `fix(deps):` and `chore(deps):`. The scope is the statement of intent,
+    # so it decides on its own, with no keyword check on top of it.
+    echo deps
+  elif [[ "$type" == chore || "$type" == ci ]] &&
+       [[ "$lower" == *update* || "$lower" == *upgrade* || "$lower" == *bump* ]] &&
+       [[ "$lower" == *dependenc* || "$lower" == *deps* || "$lower" == *version* ||
+          "$lower" == *kotlin* || "$lower" == *ksp* || "$lower" == *gradle* ]]; then
+    # A hand-written chore/ci subject that reads like a dependency bump but carries no scope.
+    # Matched case-insensitively: these are written by hand, as "Gradle", "Kotlin", "KSP".
+    echo deps
+  elif [[ "$type" == feat || "$type" == fix || "$type" == perf || "$type" == refactor ]]; then
+    echo features
+  elif [[ "$type" == docs || "$type" == chore || "$type" == ci || "$type" == style || "$type" == test ]]; then
+    echo docs
+  else
+    # Unparseable subject. Features & Fixes is the section a reader looks at first, so an
+    # unrecognized commit is surfaced rather than buried.
+    echo features
+  fi
+}
+
+self_test() {
+  local failures=0 expected subject actual
+  while IFS='|' read -r expected subject; do
+    [ -n "$expected" ] || continue
+    actual="$(categorize "$subject")"
+    if [ "$actual" = "$expected" ]; then
+      printf '  ok    %-8s  %s\n' "$actual" "$subject"
+    else
+      printf '  FAIL  expected %s, got %s:  %s\n' "$expected" "$actual" "$subject"
+      failures=$((failures + 1))
+    fi
+  done <<'CASES'
+features|feat: add a PackageScan generation mode
+features|fix: keep generated names unique per source set
+features|feat(processor): generate one file per package instead of one file per class
+features|fix(release): suggest versions by severity, not from the Kotlin version
+features|feat!: drop the AutoLog annotation
+features|feat(annotations)!: drop the AutoLog annotation
+features|Merge pull request #1 from doljae/topic
+deps|fix(deps): update dependency ch.qos.logback:logback-classic to v1.6.2
+deps|chore(deps): update gradle to v9.7.0
+deps|fix(deps): pin logback to 1.5.x
+deps|chore: update the Gradle wrapper to 9.7.0
+deps|ci: bump the KSP version used by the consumer matrix
+docs|docs: write down the issue-first contribution workflow
+docs|docs(readme): correct the compatibility table
+docs|ci(release): stop tagging the same commit twice
+docs|test(processor): cover the shadowing warning
+docs|ci: put the maintainer and the linked issue's labels on every PR
+docs|chore: remove the unused workload fixture
+CASES
+
+  if [ "$failures" -gt 0 ]; then
+    echo "$failures case(s) failed."
+    return 1
+  fi
+  echo "All cases passed."
+}
+
+case "${1:-}" in
+  --self-test) self_test ;;
+  "") echo "usage: $0 <commit subject> | --self-test" >&2; exit 2 ;;
+  *) categorize "$1" ;;
+esac


### PR DESCRIPTION
## Motivation

<!-- Why is this change needed? What is broken or missing without it? -->

Release notes matched whole commit subjects against a glob per type (`feat:*`, `docs:*`, ...). A
Conventional Commit scope sits between the type and the colon, so every scoped subject missed all of
them and fell through to the uncategorized `else`, which files the commit under "🚀 Features & Fixes".

The bug was invisible because the fallback happens to be the right answer for the scoped forms used
most here: `feat(processor):` and `fix(processor):` reach Features & Fixes by default rather than by
matching. The ones it got wrong were quieter: `chore(deps):`, which Renovate uses for Gradle and
action updates (#151, #123, #124, #125), was announced as a feature.

Closes #183

## Modification

<!-- What changed, and any decision a reviewer should know about. -->

The type and scope are parsed once per subject, and the section is chosen from the parsed type, so a
scope no longer changes the outcome. `feat!:` and `feat(api)!:` parse too.

Two deliberate behavior changes beyond the reported bug, both in the dependency branch:

- **A `deps` / `dep` scope now decides on its own.** The old condition read as "fix(deps) OR
  (chore/ci AND keywords)", but `||` and `&&` bind equally in shell and associate left to right, so
  it actually required the update/dependency keywords for the `fix(deps)` case as well. That is why
  `fix(deps): pin logback to 1.5.x` was not treated as a dependency update. The keyword check stays
  for unscoped `chore:` / `ci:` subjects, which is what it was written for.
- **The keyword check is now case-insensitive.** It matched `*gradle*` and `*ksp*` against a subject
  written by hand as "Gradle" and "KSP". The self-test caught this while it was being written.

The rule moved into `scripts/categorize-commit.sh`, which the workflow calls, with a `--self-test`
table in the same file and a CI step that runs it. Embedded in a 700-line workflow the rule could
only be exercised by cutting a release, which is how a wrong answer sat in it unnoticed. One file
rather than a script plus a test file, so the cases cannot drift away from the logic they cover.

`docs/project-instructions.md` described the old behavior, added in #182, and is updated with it.

## Result

<!-- How was it verified? Note anything the build does not cover. -->

`scripts/categorize-commit.sh --self-test`, 18 cases, passing on bash 3.2 (macOS) and run by CI on
every PR. The regex is held in a variable because bash 3.2 rejects the parentheses inline.

Before and after, over the same subjects:

```
                 before             after
chore(deps): update gradle to v9.7.0                    features(default)  deps
fix(deps): pin logback to 1.5.x                         features(default)  deps
docs(readme): correct the compatibility table           features(default)  docs
ci(release): stop tagging the same commit twice         features(default)  docs
test(processor): cover the shadowing warning            features(default)  docs
feat(processor): generate one file per package          features(default)  features
feat!: drop the AutoLog annotation                      features(default)  features
fix(deps): update dependency ...logback-classic to v1.6.2  deps            deps
```

Replayed over the real `v3.0.0..HEAD` range, the only difference is `fix(release): suggest versions
by severity` (#165), which now reaches Features & Fixes by matching rather than by falling through.

The release job itself is not exercised here: it only runs on a release, and the categorization is
the part of it this PR touches.
